### PR TITLE
install pystiche manually

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -4,6 +4,8 @@ REQUIREMENTS_FILE=ci_torch_cpu_requirements.txt
 python3 gen_torch_cpu_requirements.py --file $REQUIREMENTS_FILE
 pip3 install -r $REQUIREMENTS_FILE
 
+pip install git+https://github.com/pmeier/pystiche
+
 pip3 install -r requirements-test.txt
 
 pip3 install --upgrade .  codecov

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,9 @@ jobs:
           python gen_torch_cpu_requirements.py --file $REQUIREMENTS_FILE
           pip install -r $REQUIREMENTS_FILE
 
+      - name: Install pystiche
+        run: pip install git+https://github.com/pmeier/pystiche
+
       - name: Install pystiche_papers
         run: pip install .
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,6 +57,9 @@ jobs:
           python gen_torch_cpu_requirements.py --file $REQUIREMENTS_FILE
           pip install -r $REQUIREMENTS_FILE
 
+      - name: Install pystiche
+        run: pip install git+https://github.com/pmeier/pystiche
+
       - name: Install pystiche_papers
         run: pip install --editable .
 


### PR DESCRIPTION
Since `pystiche` is not yet listed on `pypi` we install it manually for the CI. That should be made clear in the documentation in a follow-up PR.