### PR TITLE
mock weight download

### DIFF
--- a/tests/gatys_ecker_bethge_2015/test_utils.py
+++ b/tests/gatys_ecker_bethge_2015/test_utils.py
@@ -19,9 +19,10 @@ def test_gatys_ecker_bethge_2015_postprocessor():
     )
 
 
-@pytest.mark.large_download
 @pytest.mark.slow
-def test_gatys_ecker_bethge_2015_multi_layer_encoder(subtests):
+def test_gatys_ecker_bethge_2015_multi_layer_encoder(subtests, mocker):
+    mocker.patch("pystiche.enc.models.vgg.VGGMultiLayerEncoder._load_weights")
+
     multi_layer_encoder = utils.gatys_ecker_bethge_2015_multi_layer_encoder()
     assert isinstance(multi_layer_encoder, VGGMultiLayerEncoder)
 
@@ -37,9 +38,10 @@ def test_gatys_ecker_bethge_2015_multi_layer_encoder(subtests):
         assert all(module.inplace for module in relu_modules)
 
 
-@pytest.mark.large_download
 @pytest.mark.slow
-def test_gatys_ecker_bethge_2015_multi_layer_encoder_avg_ppol():
+def test_gatys_ecker_bethge_2015_multi_layer_encoder_avg_ppol(mocker):
+    mocker.patch("pystiche.enc.models.vgg.VGGMultiLayerEncoder._load_weights")
+
     multi_layer_encoder = utils.gatys_ecker_bethge_2015_multi_layer_encoder(
         impl_params=False
     )

--- a/tests/gatys_et_al_2017/test_utils.py
+++ b/tests/gatys_et_al_2017/test_utils.py
@@ -33,9 +33,6 @@ def test_gatys_et_al_2017_multi_layer_encoder(subtests, mocker):
             if isinstance(module, nn.ReLU)
         ]
         assert all(module.inplace for module in relu_modules)
-    assert isinstance(
-        utils.gatys_et_al_2017_multi_layer_encoder(), VGGMultiLayerEncoder
-    )
 
 
 def test_gatys_et_al_2017_optimizer(subtests, input_image):

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
   ; TODO: remove this when pystiche_papers has pystiche as a requirement
   git+https://github.com/pmeier/pystiche
   pytest
+  pytest-mock
   pytest-subtests
   pytest-cov
 commands =


### PR DESCRIPTION
After pmeier/pystiche#330 has landed we can now mock the weight download to enable testing `multi_layer_encoder`s with the CI.