### PR TITLE
add load_weights mock to gatys_et_al_2017 tests

### DIFF
--- a/tests/gatys_et_al_2017/conftest.py
+++ b/tests/gatys_et_al_2017/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+
+from pystiche_papers.gatys_et_al_2017.utils import gatys_et_al_2017_multi_layer_encoder
+
+
+@pytest.fixture(scope="package")
+def vgg_load_weights_mock(package_mocker):
+    return package_mocker.patch(
+        "pystiche.enc.models.vgg.VGGMultiLayerEncoder._load_weights"
+    )
+
+
+@pytest.fixture(scope="package", autouse=True)
+def multi_layer_encoder_mock(package_mocker, vgg_load_weights_mock):
+    multi_layer_encoder = gatys_et_al_2017_multi_layer_encoder()
+
+    def new():
+        multi_layer_encoder.empty_storage()
+        return multi_layer_encoder
+
+    return package_mocker.patch(
+        "pystiche_papers.gatys_et_al_2017.loss.gatys_et_al_2017_multi_layer_encoder",
+        new,
+    )


### PR DESCRIPTION
Without this every (indirect) call to `gatys_et_al_2017_multi_layer_encoder` will load the weights. This significantly slows down the test suite.