### PR TITLE
make skipping slow tests more reliable

### DIFF
--- a/tests/data/test_nprgeneral.py
+++ b/tests/data/test_nprgeneral.py
@@ -10,6 +10,7 @@ def test_NPRgeneralLicense_smoke():
     assert isinstance(repr(image.license), str)
 
 
+@pytest.mark.slow
 def test_NPRgeneral_smoke(subtests):
     for name, image in data.NPRgeneral():
         with subtests.test(name=name):

--- a/tests/gatys_ecker_bethge_2015/test_data.py
+++ b/tests/gatys_ecker_bethge_2015/test_data.py
@@ -5,6 +5,7 @@ from pystiche_papers import gatys_ecker_bethge_2015 as paper
 from .._asserts import assert_image_downloads_correctly, assert_image_is_downloadable
 
 
+@pytest.mark.slow
 def test_gatys_ecker_bethge_2015_images_smoke(subtests):
     for name, image in paper.gatys_ecker_bethge_2015_images():
         with subtests.test(name=name):

--- a/tests/gatys_et_al_2017/test_data.py
+++ b/tests/gatys_et_al_2017/test_data.py
@@ -5,6 +5,7 @@ from pystiche_papers import gatys_et_al_2017 as paper
 from .._asserts import assert_image_downloads_correctly, assert_image_is_downloadable
 
 
+@pytest.mark.slow
 def test_gatys_et_al_2017_images_smoke(subtests):
     for name, image in paper.gatys_et_al_2017_images():
         with subtests.test(name=name):

--- a/tests/johnson_alahi_li_2016/test_core.py
+++ b/tests/johnson_alahi_li_2016/test_core.py
@@ -169,6 +169,7 @@ def training(default_transformer_optim_loop_patch, image_loader, style_image):
     return training_
 
 
+@pytest.mark.slow
 def test_johnson_alahi_li_2016_training_smoke(subtests, training, image_loader):
     args, kwargs, output = training(image_loader)
     content_image_loader, transformer, criterion, criterion_update_fn = args

--- a/tests/johnson_alahi_li_2016/test_data.py
+++ b/tests/johnson_alahi_li_2016/test_data.py
@@ -70,6 +70,7 @@ def test_johnson_alahi_li_2016_style_transform(subtests):
                 assert style_transform.edge == "long"
 
 
+@pytest.mark.slow
 def test_johnson_alahi_li_2016_images_smoke(subtests):
     for name, image in paper.johnson_alahi_li_2016_images():
         with subtests.test(name=name):

--- a/tests/li_wand_2016/test_data.py
+++ b/tests/li_wand_2016/test_data.py
@@ -5,6 +5,7 @@ from pystiche_papers import li_wand_2016 as paper
 from .._asserts import assert_image_downloads_correctly, assert_image_is_downloadable
 
 
+@pytest.mark.slow
 def test_li_wand_2016_images_smoke(subtests):
     for name, image in paper.li_wand_2016_images():
         with subtests.test(name=name):

--- a/tests/ulyanov_et_al_2016/test_data.py
+++ b/tests/ulyanov_et_al_2016/test_data.py
@@ -5,6 +5,7 @@ from pystiche_papers import ulyanov_et_al_2016 as paper
 from .._asserts import assert_image_downloads_correctly, assert_image_is_downloadable
 
 
+@pytest.mark.slow
 def test_ulyanov_et_al_2016_images_smoke(subtests):
     for name, image in paper.ulyanov_et_al_2016_images():
         with subtests.test(name=name):

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ deps =
 commands =
   pytest \
     -c pytest.ini \
+    --durations=25 \
     --cov=pystiche_papers \
     --cov-report=xml \
     --cov-config=.coveragerc \


### PR DESCRIPTION
This adds more `@pytest.mark.slow` decorators and includes the test duration report after running.