### PR TITLE
refactor weights URL selection for Johnson 2016

### DIFF
--- a/pystiche_papers/johnson_alahi_li_2016/core.py
+++ b/pystiche_papers/johnson_alahi_li_2016/core.py
@@ -114,7 +114,7 @@ def johnson_alahi_li_2016_stylization(
     transformer: Union[nn.Module, str],
     impl_params: bool = True,
     instance_norm: Optional[bool] = None,
-    weights: str = "pystiche",
+    framework: str = "pystiche",
     preprocessor: Optional[nn.Module] = None,
     postprocessor: Optional[nn.Module] = None,
 ) -> torch.Tensor:
@@ -127,7 +127,7 @@ def johnson_alahi_li_2016_stylization(
         style = transformer
         transformer = johnson_alahi_li_2016_transformer(
             style=style,
-            weights=weights,
+            framework=framework,
             impl_params=impl_params,
             instance_norm=instance_norm,
         )

--- a/pystiche_papers/johnson_alahi_li_2016/model_urls.csv
+++ b/pystiche_papers/johnson_alahi_li_2016/model_urls.csv
@@ -1,0 +1,11 @@
+framework,style,impl_params,instance_norm,url
+luatorch,candy,True,True,https://download.pystiche.org/models/johnson_alahi_li_2016_transformer__candy__impl_params__instance_norm-9e7232f6.pth
+luatorch,composition_vii,True,False,https://download.pystiche.org/models/johnson_alahi_li_2016_transformer__composition_vii__impl_params-f2ea4551.pth
+luatorch,feathers,True,True,https://download.pystiche.org/models/johnson_alahi_li_2016_transformer__feathers__impl_params__instance_norm-adc40e13.pth
+luatorch,la_muse,True,False,https://download.pystiche.org/models/johnson_alahi_li_2016_transformer__la_muse__impl_params-9314f997.pth
+luatorch,la_muse,True,True,https://download.pystiche.org/models/johnson_alahi_li_2016_transformer__la_muse__impl_params__instance_norm-8707503f.pth
+luatorch,mosaic,True,True,https://download.pystiche.org/models/johnson_alahi_li_2016_transformer__mosaic__impl_params__instance_norm-473bf61c.pth
+luatorch,starry_night,True,False,https://download.pystiche.org/models/johnson_alahi_li_2016_transformer__starry_night__impl_params-e451b759.pth
+luatorch,the_scream,True,True,https://download.pystiche.org/models/johnson_alahi_li_2016_transformer__the_scream__impl_params__instance_norm-fcc9e645.pth
+luatorch,the_wave,True,False,https://download.pystiche.org/models/johnson_alahi_li_2016_transformer__the_wave__impl_params-d81a9d37.pth
+luatorch,udnie,True,True,https://download.pystiche.org/models/johnson_alahi_li_2016_transformer__udnie__impl_params__instance_norm-dd85f0fb.pth

--- a/pystiche_papers/johnson_alahi_li_2016/modules.py
+++ b/pystiche_papers/johnson_alahi_li_2016/modules.py
@@ -37,6 +37,8 @@ def _load_model_urls() -> Dict[Tuple[str, str, bool, bool], str]:
         }
 
 
+# The LuaTorch weights were created by Justin Johnson, Alexandre Alahi, and Fei-Fei Li.
+# See https://download.pystiche.org/models/LICENSE for details.
 MODEL_URLS = _load_model_urls()
 
 

--- a/pystiche_papers/johnson_alahi_li_2016/modules.py
+++ b/pystiche_papers/johnson_alahi_li_2016/modules.py
@@ -21,7 +21,7 @@ __all__ = [
 ]
 
 
-def _load_model_urls():
+def _load_model_urls() -> Dict[Tuple[str, str, bool, bool], str]:
     def str_to_bool(string: str) -> bool:
         return string.lower() == "true"
 

--- a/pystiche_papers/johnson_alahi_li_2016/modules.py
+++ b/pystiche_papers/johnson_alahi_li_2016/modules.py
@@ -290,7 +290,7 @@ class JohnsonAlahiLi2016Transformer(nn.Module):
 
 def johnson_alahi_li_2016_transformer(
     style: Optional[str] = None,
-    weights: str = "pystiche",
+    framework: str = "pystiche",
     impl_params: bool = True,
     instance_norm: bool = True,
 ) -> JohnsonAlahiLi2016Transformer:
@@ -305,8 +305,8 @@ def johnson_alahi_li_2016_transformer(
         return transformer
 
     url = select_url(
-        cast(str, style),
-        weights=weights,
+        framework=framework,
+        style=cast(str, style),
         impl_params=impl_params,
         instance_norm=instance_norm,
     )

--- a/tests/johnson_alahi_li_2016/test_core.py
+++ b/tests/johnson_alahi_li_2016/test_core.py
@@ -510,8 +510,8 @@ def test_johnson_alahi_li_2016_stylization_transformer_str(
     patch, mock = transformer_mocks
 
     style = "style"
-    weights = "weights"
-    stylization(transformer_=style, weights=weights)
+    framework = "pystiche"
+    stylization(transformer_=style, framework=framework)
 
     patch.assert_called_once()
     _, kwargs = patch.call_args
@@ -519,8 +519,8 @@ def test_johnson_alahi_li_2016_stylization_transformer_str(
     with subtests.test("style"):
         assert kwargs["style"] == style
 
-    with subtests.test("weights"):
-        assert kwargs["weights"] == weights
+    with subtests.test("framework"):
+        assert kwargs["framework"] == framework
 
     with subtests.test("eval"):
         mock.eval.assert_called_once_with()


### PR DESCRIPTION
Due to the number of possible combinations this stores the weight URLs in a `.csv` rather than directly as a dictionary. Tests for this will be incorporated in #82.

This will not work until `torch==1.6.0` hits since our download server requires a custom `User-Agent` in the download request. I've sent a [patch](https://github.com/pytorch/pytorch/pull/39740) for this that will be included in the upcoming release.