### PR TITLE
require pytest < 6 since it breaks pytest-subtests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
   git+https://github.com/pmeier/pytorch_testing_utils
   ; TODO: remove this when pystiche_papers has pystiche as a requirement
   git+https://github.com/pmeier/pystiche
-  pytest
+  pytest < 6
   pytest-mock >= 3.1
   pytest-subtests
   pytest-cov


### PR DESCRIPTION
See https://github.com/pytest-dev/pytest-subtests/issues/31