### PR TITLE
temporarily split off windows tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,10 +20,10 @@ on:
       - "tox.ini"
 
 jobs:
-  unit:
+  linux-macos:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         python: [3.6, 3.7, 3.8]
       fail-fast: true
 
@@ -49,6 +49,45 @@ jobs:
       - name: Install dev requirements
         run: pip install -r requirements-dev.txt
         
+      - name: Create environment
+        run: tox -e py --notest
+
+      - name: Run tests
+        run: tox -e py -- --skip-large-download
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v1.0.7
+        with:
+          env_vars: OS,PYTHON
+
+  windows:
+    strategy:
+      matrix:
+        python: [3.6, 3.7, 3.8]
+      fail-fast: true
+
+    runs-on: windows-latest
+    env:
+      OS: windows-latest
+      PYTHON: ${{ matrix.python }}
+
+    steps:
+      - name: Set up python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Upgrade and install additional system packages
+        run: pip install --user --upgrade pip setuptools
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install dev requirements
+        run: pip install --user -r requirements-dev.txt
+
       - name: Create environment
         run: tox -e py --notest
 


### PR DESCRIPTION
For yet unknown reasons, as of this morning (29 July 2020) `pip install` requires the `--user` flag when running on a Windows machine in GitHub actions. I've opened a report [here](https://github.community/t/pip-install-suddenly-requires-user-flag-on-windows/125056). 

This splits the workflow in `linux-macos` and `windows` to account for the differences. This should be reverted when the behavior change in GitHub Actions is resolved.

Test failure is expected and will be handled in #97.