### PR TITLE
require pip<20.2 since it breaks CI on windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Upgrade and install additional system packages
-        run: pip install --upgrade pip setuptools
+        run: pip install --upgrade "pip<20.2" setuptools
 
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Supersedes #98.

This should be reverted when `pip` is fixed. Test failure is expected and will be handled in #97.