### PR TITLE
run workflows on a daily schedule

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,9 @@ on:
       - "requirements-dev.txt"
       - "setup.cfg"
       - "tox.ini"
+        
+  schedule:
+    - cron: "0 4 * * *"
 
 jobs:
   sphinx:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,9 @@ on:
       - "setup.cfg"
       - "tox.ini"
 
+  schedule:
+    - cron: "0 4 * * *"
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,9 @@ on:
       - "setup.cfg"
       - "tox.ini"
 
+  schedule:
+    - cron: "0 4 * * *"
+
 jobs:
   unit:
     strategy:


### PR DESCRIPTION
This schedules the `docs`, `tests`, and `lint` workflows to run daily. This should make it easier to detect breaking changes from dependencies