### PR TITLE
enable pytest >= 6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,9 +14,9 @@ deps =
   git+https://github.com/pmeier/pytorch_testing_utils
   ; TODO: remove this when pystiche_papers has pystiche as a requirement
   git+https://github.com/pmeier/pystiche
-  pytest < 6
+  pytest >= 6
   pytest-mock >= 3.1
-  pytest-subtests
+  pytest-subtests >= 0.3.2
   pytest-cov
 commands =
   pytest \


### PR DESCRIPTION
This reverts #97 since https://github.com/pytest-dev/pytest-subtests/pull/32 fixes the `pytest==6` support for `pytest-subtests`.