### PR TITLE
Add paper impl_params permalinks

### DIFF
--- a/pystiche_papers/gatys_ecker_bethge_2016/_loss.py
+++ b/pystiche_papers/gatys_ecker_bethge_2016/_loss.py
@@ -25,8 +25,8 @@ class FeatureReconstructionOperator(ops.FeatureReconstructionOperator):
     ):
         super().__init__(encoder, score_weight=score_weight)
 
-        # In paragraph [8]:
         # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb
+        # Cell [8]
         # torch.nn.MSELoss() was used to calculate the content loss, which does not
         # include the factor 1/2 given in the paper
         self.score_correction_factor = 1.0 if impl_params else 1.0 / 2.0

--- a/pystiche_papers/gatys_ecker_bethge_2016/_loss.py
+++ b/pystiche_papers/gatys_ecker_bethge_2016/_loss.py
@@ -25,9 +25,12 @@ class FeatureReconstructionOperator(ops.FeatureReconstructionOperator):
     ):
         super().__init__(encoder, score_weight=score_weight)
 
-        # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [3]
+        # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [8]
+        # torch.nn.MSELoss() was used to calculate the content loss, which does not include the factor 1/2
+        # given in the paper
         self.score_correction_factor = 1.0 if impl_params else 1.0 / 2.0
-        # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [9]
+        # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [8]
+        # torch.nn.MSELoss() was used to calculate the content loss, which by default uses reduction="mean"
         self.loss_reduction = "mean" if impl_params else "sum"
 
     def calculate_score(
@@ -73,6 +76,8 @@ class StyleLoss(ops.MultiLayerEncodingOperator):
             score_weight=score_weight,
         )
         # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [3]
+        # torch.nn.MSELoss() was used to calculate the style loss, which does not include the factor 1/4
+        # given in the paper
         self.score_correction_factor = 1.0 if impl_params else 1.0 / 4.0
 
     def process_input_image(self, input_image: torch.Tensor) -> pystiche.LossDict:

--- a/pystiche_papers/gatys_ecker_bethge_2016/_loss.py
+++ b/pystiche_papers/gatys_ecker_bethge_2016/_loss.py
@@ -25,11 +25,13 @@ class FeatureReconstructionOperator(ops.FeatureReconstructionOperator):
     ):
         super().__init__(encoder, score_weight=score_weight)
 
-        # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [8]
+        # In paragraph [8]:
+        # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb
         # torch.nn.MSELoss() was used to calculate the content loss, which does not
         # include the factor 1/2 given in the paper
         self.score_correction_factor = 1.0 if impl_params else 1.0 / 2.0
-        # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [8]
+        # In paragraph [8]:
+        # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb
         # torch.nn.MSELoss() was used to calculate the content loss, which by default
         # uses reduction="mean"
         self.loss_reduction = "mean" if impl_params else "sum"
@@ -76,7 +78,8 @@ class StyleLoss(ops.MultiLayerEncodingOperator):
             layer_weights=layer_weights,
             score_weight=score_weight,
         )
-        # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [3]
+        # In paragraph [3]:
+        # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb
         # torch.nn.MSELoss() was used to calculate the style loss, which does not
         # include the factor 1/4 given in the paper
         self.score_correction_factor = 1.0 if impl_params else 1.0 / 4.0

--- a/pystiche_papers/gatys_ecker_bethge_2016/_loss.py
+++ b/pystiche_papers/gatys_ecker_bethge_2016/_loss.py
@@ -30,8 +30,8 @@ class FeatureReconstructionOperator(ops.FeatureReconstructionOperator):
         # torch.nn.MSELoss() was used to calculate the content loss, which does not
         # include the factor 1/2 given in the paper
         self.score_correction_factor = 1.0 if impl_params else 1.0 / 2.0
-        # In paragraph [8]:
         # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb
+        # Cell [8]
         # torch.nn.MSELoss() was used to calculate the content loss, which by default
         # uses reduction="mean"
         self.loss_reduction = "mean" if impl_params else "sum"
@@ -78,8 +78,8 @@ class StyleLoss(ops.MultiLayerEncodingOperator):
             layer_weights=layer_weights,
             score_weight=score_weight,
         )
-        # In paragraph [3]:
         # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb
+        # Cell [3]
         # torch.nn.MSELoss() was used to calculate the style loss, which does not
         # include the factor 1/4 given in the paper
         self.score_correction_factor = 1.0 if impl_params else 1.0 / 4.0

--- a/pystiche_papers/gatys_ecker_bethge_2016/_loss.py
+++ b/pystiche_papers/gatys_ecker_bethge_2016/_loss.py
@@ -25,13 +25,9 @@ class FeatureReconstructionOperator(ops.FeatureReconstructionOperator):
     ):
         super().__init__(encoder, score_weight=score_weight)
 
-        """
-        https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [3]
-        """
+        # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [3]
         self.score_correction_factor = 1.0 if impl_params else 1.0 / 2.0
-        """
-        https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [9]
-        """
+        # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [9]
         self.loss_reduction = "mean" if impl_params else "sum"
 
     def calculate_score(
@@ -76,9 +72,7 @@ class StyleLoss(ops.MultiLayerEncodingOperator):
             layer_weights=layer_weights,
             score_weight=score_weight,
         )
-        """
-        https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [3]
-        """
+        # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [3]
         self.score_correction_factor = 1.0 if impl_params else 1.0 / 4.0
 
     def process_input_image(self, input_image: torch.Tensor) -> pystiche.LossDict:

--- a/pystiche_papers/gatys_ecker_bethge_2016/_loss.py
+++ b/pystiche_papers/gatys_ecker_bethge_2016/_loss.py
@@ -25,7 +25,13 @@ class FeatureReconstructionOperator(ops.FeatureReconstructionOperator):
     ):
         super().__init__(encoder, score_weight=score_weight)
 
+        """
+        https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [3]
+        """
         self.score_correction_factor = 1.0 if impl_params else 1.0 / 2.0
+        """
+        https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [9]
+        """
         self.loss_reduction = "mean" if impl_params else "sum"
 
     def calculate_score(
@@ -70,7 +76,9 @@ class StyleLoss(ops.MultiLayerEncodingOperator):
             layer_weights=layer_weights,
             score_weight=score_weight,
         )
-
+        """
+        https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [3]
+        """
         self.score_correction_factor = 1.0 if impl_params else 1.0 / 4.0
 
     def process_input_image(self, input_image: torch.Tensor) -> pystiche.LossDict:

--- a/pystiche_papers/gatys_ecker_bethge_2016/_loss.py
+++ b/pystiche_papers/gatys_ecker_bethge_2016/_loss.py
@@ -26,11 +26,12 @@ class FeatureReconstructionOperator(ops.FeatureReconstructionOperator):
         super().__init__(encoder, score_weight=score_weight)
 
         # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [8]
-        # torch.nn.MSELoss() was used to calculate the content loss, which does not include the factor 1/2
-        # given in the paper
+        # torch.nn.MSELoss() was used to calculate the content loss, which does not
+        # include the factor 1/2 given in the paper
         self.score_correction_factor = 1.0 if impl_params else 1.0 / 2.0
         # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [8]
-        # torch.nn.MSELoss() was used to calculate the content loss, which by default uses reduction="mean"
+        # torch.nn.MSELoss() was used to calculate the content loss, which by default
+        # uses reduction="mean"
         self.loss_reduction = "mean" if impl_params else "sum"
 
     def calculate_score(
@@ -76,8 +77,8 @@ class StyleLoss(ops.MultiLayerEncodingOperator):
             score_weight=score_weight,
         )
         # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [3]
-        # torch.nn.MSELoss() was used to calculate the style loss, which does not include the factor 1/4
-        # given in the paper
+        # torch.nn.MSELoss() was used to calculate the style loss, which does not
+        # include the factor 1/4 given in the paper
         self.score_correction_factor = 1.0 if impl_params else 1.0 / 4.0
 
     def process_input_image(self, input_image: torch.Tensor) -> pystiche.LossDict:

--- a/pystiche_papers/gatys_ecker_bethge_2016/_nst.py
+++ b/pystiche_papers/gatys_ecker_bethge_2016/_nst.py
@@ -33,6 +33,9 @@ def nst(
     device = content_image.device
     criterion = criterion.to(device)
 
+    """
+    https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [6]
+    """
     starting_point = "content" if impl_params else "random"
     input_image = misc.get_input_image(
         starting_point=starting_point, content_image=content_image

--- a/pystiche_papers/gatys_ecker_bethge_2016/_nst.py
+++ b/pystiche_papers/gatys_ecker_bethge_2016/_nst.py
@@ -33,7 +33,6 @@ def nst(
     device = content_image.device
     criterion = criterion.to(device)
 
-
     # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [6]
     starting_point = "content" if impl_params else "random"
     input_image = misc.get_input_image(

--- a/pystiche_papers/gatys_ecker_bethge_2016/_nst.py
+++ b/pystiche_papers/gatys_ecker_bethge_2016/_nst.py
@@ -33,7 +33,8 @@ def nst(
     device = content_image.device
     criterion = criterion.to(device)
 
-    # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [6]
+    # In paragraph [6]:
+    # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb
     starting_point = "content" if impl_params else "random"
     input_image = misc.get_input_image(
         starting_point=starting_point, content_image=content_image

--- a/pystiche_papers/gatys_ecker_bethge_2016/_nst.py
+++ b/pystiche_papers/gatys_ecker_bethge_2016/_nst.py
@@ -33,9 +33,8 @@ def nst(
     device = content_image.device
     criterion = criterion.to(device)
 
-    """
-    https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [6]
-    """
+
+    # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb [6]
     starting_point = "content" if impl_params else "random"
     input_image = misc.get_input_image(
         starting_point=starting_point, content_image=content_image

--- a/pystiche_papers/gatys_ecker_bethge_2016/_nst.py
+++ b/pystiche_papers/gatys_ecker_bethge_2016/_nst.py
@@ -33,8 +33,8 @@ def nst(
     device = content_image.device
     criterion = criterion.to(device)
 
-    # In paragraph [6]:
     # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb
+    # Cell [6]
     starting_point = "content" if impl_params else "random"
     input_image = misc.get_input_image(
         starting_point=starting_point, content_image=content_image

--- a/pystiche_papers/gatys_et_al_2017/_loss.py
+++ b/pystiche_papers/gatys_et_al_2017/_loss.py
@@ -49,7 +49,9 @@ class StyleLoss(ops.MultiLayerEncodingOperator):
             layer_weights=layer_weights,
             score_weight=score_weight,
         )
-
+        """
+        https://github.com/pmeier/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/LossLayers.lua#L80
+        """
         self.score_correction_factor = 1.0 if impl_params else 1.0 / 4.0
 
     @staticmethod

--- a/pystiche_papers/gatys_et_al_2017/_loss.py
+++ b/pystiche_papers/gatys_et_al_2017/_loss.py
@@ -49,9 +49,7 @@ class StyleLoss(ops.MultiLayerEncodingOperator):
             layer_weights=layer_weights,
             score_weight=score_weight,
         )
-        """
-        https://github.com/pmeier/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/LossLayers.lua#L80
-        """
+        # https://github.com/pmeier/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/LossLayers.lua#L80
         self.score_correction_factor = 1.0 if impl_params else 1.0 / 4.0
 
     @staticmethod

--- a/pystiche_papers/gatys_et_al_2017/_loss.py
+++ b/pystiche_papers/gatys_et_al_2017/_loss.py
@@ -49,7 +49,10 @@ class StyleLoss(ops.MultiLayerEncodingOperator):
             layer_weights=layer_weights,
             score_weight=score_weight,
         )
-        # https://github.com/pmeier/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/LossLayers.lua#L80
+        # https://github.com/pmeier/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/LossLayers.lua#L63
+        # https://github.com/pmeier/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/LossLayers.lua#L75
+        # torch.nn.MSELoss() was used as criterion for the content loss, which does not include the factor 1/4
+        # given in the paper
         self.score_correction_factor = 1.0 if impl_params else 1.0 / 4.0
 
     @staticmethod

--- a/pystiche_papers/gatys_et_al_2017/_loss.py
+++ b/pystiche_papers/gatys_et_al_2017/_loss.py
@@ -51,8 +51,8 @@ class StyleLoss(ops.MultiLayerEncodingOperator):
         )
         # https://github.com/pmeier/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/LossLayers.lua#L63
         # https://github.com/pmeier/NeuralImageSynthesis/blob/cced0b978fe603569033b2c7f04460839e4d82c4/LossLayers.lua#L75
-        # torch.nn.MSELoss() was used as criterion for the content loss, which does not include the factor 1/4
-        # given in the paper
+        # torch.nn.MSELoss() was used as criterion for the content loss, which does not
+        # include the factor 1/4 given in the paper
         self.score_correction_factor = 1.0 if impl_params else 1.0 / 4.0
 
     @staticmethod

--- a/pystiche_papers/johnson_alahi_li_2016/_data.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_data.py
@@ -78,6 +78,7 @@ def get_style_edge_size(
     )
 
 
+
 def style_transform(
     impl_params: bool = True,
     instance_norm: bool = True,

--- a/pystiche_papers/johnson_alahi_li_2016/_data.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_data.py
@@ -78,7 +78,6 @@ def get_style_edge_size(
     )
 
 
-
 def style_transform(
     impl_params: bool = True,
     instance_norm: bool = True,

--- a/pystiche_papers/johnson_alahi_li_2016/_modules.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_modules.py
@@ -204,7 +204,9 @@ def decoder(
 ) -> pystiche.SequentialModule:
     def get_value_range_delimiter() -> nn.Module:
         if impl_params:
-
+            """
+            https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/train.lua#L25
+            """
             def value_range_delimiter(x: torch.Tensor) -> torch.Tensor:
                 return 150.0 * torch.tanh(x)
 

--- a/pystiche_papers/johnson_alahi_li_2016/_modules.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_modules.py
@@ -205,6 +205,8 @@ def decoder(
     def get_value_range_delimiter() -> nn.Module:
         if impl_params:
             # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/train.lua#L25
+            # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/fast_neural_style/models.lua#L137-L138
+            # A tanh with a constant factor of 150 is used instead of the (tanh(x) + 1) / 2 in the paper.
             def value_range_delimiter(x: torch.Tensor) -> torch.Tensor:
                 return 150.0 * torch.tanh(x)
 

--- a/pystiche_papers/johnson_alahi_li_2016/_modules.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_modules.py
@@ -206,7 +206,8 @@ def decoder(
         if impl_params:
             # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/train.lua#L25
             # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/fast_neural_style/models.lua#L137-L138
-            # A tanh with a constant factor of 150 is used instead of the (tanh(x) + 1) / 2 in the paper.
+            # A tanh with a constant factor of 150 is used instead of the
+            # (tanh(x) + 1) / 2 in the paper.
             def value_range_delimiter(x: torch.Tensor) -> torch.Tensor:
                 return 150.0 * torch.tanh(x)
 

--- a/pystiche_papers/johnson_alahi_li_2016/_modules.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_modules.py
@@ -204,9 +204,7 @@ def decoder(
 ) -> pystiche.SequentialModule:
     def get_value_range_delimiter() -> nn.Module:
         if impl_params:
-            """
-            https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/train.lua#L25
-            """
+            # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/train.lua#L25
             def value_range_delimiter(x: torch.Tensor) -> torch.Tensor:
                 return 150.0 * torch.tanh(x)
 

--- a/pystiche_papers/johnson_alahi_li_2016/_nst.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_nst.py
@@ -71,6 +71,9 @@ def training(
 
     if impl_params:
         preprocessor = _preprocessor()
+        """
+        https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/slow_neural_style.lua#L111
+        """
         preprocessor = preprocessor.to(device)
         style_image = preprocessor(style_image)
 
@@ -117,11 +120,20 @@ def stylization(
     transformer = transformer.to(device)
 
     if impl_params and preprocessor is None:
+        """
+        content:
+        https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/slow_neural_style.lua#L104
+        style:
+        https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/slow_neural_style.lua#L111
+        """
         preprocessor = _preprocessor()
 
     if impl_params and postprocessor is None:
+        """
+        https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/slow_neural_style.lua#L137
+        """
         postprocessor = _postprocessor()
-
+        
     with torch.no_grad():
         if preprocessor is not None:
             preprocessor = preprocessor.to(device)

--- a/pystiche_papers/johnson_alahi_li_2016/_nst.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_nst.py
@@ -71,6 +71,7 @@ def training(
 
     if impl_params:
         # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/slow_neural_style.lua#L111
+        # A preprocessor is used in the implementation, which is not documented in the paper.
         preprocessor = _preprocessor()
         preprocessor = preprocessor.to(device)
         style_image = preprocessor(style_image)
@@ -118,6 +119,7 @@ def stylization(
     transformer = transformer.to(device)
 
     if impl_params and preprocessor is None:
+        # A preprocessor is used in the implementation, which is not documented in the paper.
         # content:
         # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/slow_neural_style.lua#L104
         # style:
@@ -125,6 +127,7 @@ def stylization(
         preprocessor = _preprocessor()
 
     if impl_params and postprocessor is None:
+        # A postprocessor is used in the implementation, which is not documented in the paper.
         # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/slow_neural_style.lua#L137
         postprocessor = _postprocessor()
 

--- a/pystiche_papers/johnson_alahi_li_2016/_nst.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_nst.py
@@ -70,10 +70,8 @@ def training(
     style_image = batch_up_image(style_image, loader=content_image_loader)
 
     if impl_params:
+        # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/slow_neural_style.lua#L111
         preprocessor = _preprocessor()
-        """
-        https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/slow_neural_style.lua#L111
-        """
         preprocessor = preprocessor.to(device)
         style_image = preprocessor(style_image)
 
@@ -129,11 +127,9 @@ def stylization(
         preprocessor = _preprocessor()
 
     if impl_params and postprocessor is None:
-        """
-        https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/slow_neural_style.lua#L137
-        """
+        # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/slow_neural_style.lua#L137
         postprocessor = _postprocessor()
-        
+
     with torch.no_grad():
         if preprocessor is not None:
             preprocessor = preprocessor.to(device)

--- a/pystiche_papers/johnson_alahi_li_2016/_nst.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_nst.py
@@ -71,7 +71,8 @@ def training(
 
     if impl_params:
         # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/slow_neural_style.lua#L111
-        # A preprocessor is used in the implementation, which is not documented in the paper.
+        # A preprocessor is used in the implementation, which is not documented in the
+        # paper.
         preprocessor = _preprocessor()
         preprocessor = preprocessor.to(device)
         style_image = preprocessor(style_image)
@@ -119,7 +120,8 @@ def stylization(
     transformer = transformer.to(device)
 
     if impl_params and preprocessor is None:
-        # A preprocessor is used in the implementation, which is not documented in the paper.
+        # A preprocessor is used in the implementation, which is not documented in the
+        # paper.
         # content:
         # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/slow_neural_style.lua#L104
         # style:
@@ -127,7 +129,8 @@ def stylization(
         preprocessor = _preprocessor()
 
     if impl_params and postprocessor is None:
-        # A postprocessor is used in the implementation, which is not documented in the paper.
+        # A postprocessor is used in the implementation, which is not documented in the
+        # paper.
         # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/slow_neural_style.lua#L137
         postprocessor = _postprocessor()
 

--- a/pystiche_papers/johnson_alahi_li_2016/_nst.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_nst.py
@@ -118,12 +118,10 @@ def stylization(
     transformer = transformer.to(device)
 
     if impl_params and preprocessor is None:
-        """
-        content:
-        https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/slow_neural_style.lua#L104
-        style:
-        https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/slow_neural_style.lua#L111
-        """
+        # content:
+        # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/slow_neural_style.lua#L104
+        # style:
+        # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/slow_neural_style.lua#L111
         preprocessor = _preprocessor()
 
     if impl_params and postprocessor is None:

--- a/pystiche_papers/li_wand_2016/_loss.py
+++ b/pystiche_papers/li_wand_2016/_loss.py
@@ -32,7 +32,7 @@ class FeatureReconstructionOperator(ops.FeatureReconstructionOperator):
         super().__init__(encoder, **feature_reconstruction_op_kwargs)
 
         # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/mylib/content.lua#L15
-        # nn.MSECriterion() was used to calculate the content loss, which by default uses reduction="mean"
+        # nn.MSECriterion() was used as criterion to calculate the content loss, which by default uses reduction="mean"
         self.loss_reduction = "mean" if impl_params else "sum"
 
     def calculate_score(
@@ -79,7 +79,7 @@ class MRFOperator(ops.MRFOperator):
         self.normalize_patches_grad = impl_params
         self.loss_reduction = "sum"
         # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/mylib/style.lua#L34
-        # nn.MSECriterion() was used to calculate the style loss, which does not include the factor 1/2
+        # nn.MSECriterion() was used as criterion to calculate the style loss, which does not include the factor 1/2
         # given in the paper
         self.score_correction_factor = 1.0 / 2.0 if impl_params else 1.0
 

--- a/pystiche_papers/li_wand_2016/_loss.py
+++ b/pystiche_papers/li_wand_2016/_loss.py
@@ -32,7 +32,6 @@ class FeatureReconstructionOperator(ops.FeatureReconstructionOperator):
         super().__init__(encoder, **feature_reconstruction_op_kwargs)
 
         # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/transfer_CNNMRF_wrapper.lua#L85
-
         self.loss_reduction = "mean" if impl_params else "sum"
 
     def calculate_score(

--- a/pystiche_papers/li_wand_2016/_loss.py
+++ b/pystiche_papers/li_wand_2016/_loss.py
@@ -31,6 +31,8 @@ class FeatureReconstructionOperator(ops.FeatureReconstructionOperator):
     ):
         super().__init__(encoder, **feature_reconstruction_op_kwargs)
 
+         # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/transfer_CNNMRF_wrapper.lua#L85
+
         self.loss_reduction = "mean" if impl_params else "sum"
 
     def calculate_score(
@@ -53,6 +55,7 @@ def content_loss(
     encoder = multi_layer_encoder.extract_encoder(layer)
 
     if score_weight is None:
+        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/cnnmrf.lua#L58
         score_weight = 2e1 if impl_params else 1e0
 
     return FeatureReconstructionOperator(
@@ -71,8 +74,10 @@ class MRFOperator(ops.MRFOperator):
 
         super().__init__(encoder, patch_size, **mrf_op_kwargs)
 
+        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/mylib/mrf.lua#L108
         self.normalize_patches_grad = impl_params
         self.loss_reduction = "sum"
+        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/mylib/style.lua#L34
         self.score_correction_factor = 1.0 / 2.0 if impl_params else 1.0
 
     def enc_to_repr(self, enc: torch.Tensor, is_guided: bool) -> torch.Tensor:
@@ -112,11 +117,14 @@ def style_loss(
         layers = ("relu3_1", "relu4_1")
 
     if stride is None:
+        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/cnnmrf.lua#L53
         stride = 2 if impl_params else 1
 
     if target_transforms is None:
+        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/cnnmrf.lua#L52
         num_scale_steps = 1 if impl_params else 3
         scale_step_width = 5e-2
+        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/cnnmrf.lua#L51
         num_rotate_steps = 1 if impl_params else 2
         rotate_step_width = 7.5
         target_transforms = MRFOperator.scale_and_rotate_transforms(
@@ -137,6 +145,7 @@ def style_loss(
         )
 
     if score_weight is None:
+        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/cnnmrf.lua#L49
         score_weight = 1e-4 if impl_params else 1e0
 
     return ops.MultiLayerEncodingOperator(

--- a/pystiche_papers/li_wand_2016/_loss.py
+++ b/pystiche_papers/li_wand_2016/_loss.py
@@ -32,7 +32,8 @@ class FeatureReconstructionOperator(ops.FeatureReconstructionOperator):
         super().__init__(encoder, **feature_reconstruction_op_kwargs)
 
         # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/mylib/content.lua#L15
-        # nn.MSECriterion() was used as criterion to calculate the content loss, which by default uses reduction="mean"
+        # nn.MSECriterion() was used as criterion to calculate the content loss, which
+        # by default uses reduction="mean"
         self.loss_reduction = "mean" if impl_params else "sum"
 
     def calculate_score(
@@ -75,12 +76,13 @@ class MRFOperator(ops.MRFOperator):
         super().__init__(encoder, patch_size, **mrf_op_kwargs)
 
         # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/mylib/mrf.lua#L108
-        # They use normalized patches instead of the unnormalized patches described in the paper.
+        # They use normalized patches instead of the unnormalized patches described in
+        # the paper.
         self.normalize_patches_grad = impl_params
         self.loss_reduction = "sum"
         # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/mylib/style.lua#L34
-        # nn.MSECriterion() was used as criterion to calculate the style loss, which does not include the factor 1/2
-        # given in the paper
+        # nn.MSECriterion() was used as criterion to calculate the style loss, which
+        # does not include the factor 1/2 given in the paper
         self.score_correction_factor = 1.0 / 2.0 if impl_params else 1.0
 
     def enc_to_repr(self, enc: torch.Tensor, is_guided: bool) -> torch.Tensor:

--- a/pystiche_papers/li_wand_2016/_loss.py
+++ b/pystiche_papers/li_wand_2016/_loss.py
@@ -31,7 +31,7 @@ class FeatureReconstructionOperator(ops.FeatureReconstructionOperator):
     ):
         super().__init__(encoder, **feature_reconstruction_op_kwargs)
 
-         # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/transfer_CNNMRF_wrapper.lua#L85
+        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/transfer_CNNMRF_wrapper.lua#L85
 
         self.loss_reduction = "mean" if impl_params else "sum"
 

--- a/pystiche_papers/li_wand_2016/_loss.py
+++ b/pystiche_papers/li_wand_2016/_loss.py
@@ -31,7 +31,8 @@ class FeatureReconstructionOperator(ops.FeatureReconstructionOperator):
     ):
         super().__init__(encoder, **feature_reconstruction_op_kwargs)
 
-        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/transfer_CNNMRF_wrapper.lua#L85
+        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/mylib/content.lua#L15
+        # nn.MSECriterion() was used to calculate the content loss, which by default uses reduction="mean"
         self.loss_reduction = "mean" if impl_params else "sum"
 
     def calculate_score(
@@ -74,9 +75,12 @@ class MRFOperator(ops.MRFOperator):
         super().__init__(encoder, patch_size, **mrf_op_kwargs)
 
         # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/mylib/mrf.lua#L108
+        # They use normalized patches instead of the unnormalized patches described in the paper.
         self.normalize_patches_grad = impl_params
         self.loss_reduction = "sum"
         # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/mylib/style.lua#L34
+        # nn.MSECriterion() was used to calculate the style loss, which does not include the factor 1/2
+        # given in the paper
         self.score_correction_factor = 1.0 / 2.0 if impl_params else 1.0
 
     def enc_to_repr(self, enc: torch.Tensor, is_guided: bool) -> torch.Tensor:

--- a/pystiche_papers/li_wand_2016/_pyramid.py
+++ b/pystiche_papers/li_wand_2016/_pyramid.py
@@ -15,9 +15,11 @@ def image_pyramid(
     **octave_image_pyramid_kwargs: Any,
 ) -> pyramid.OctaveImagePyramid:
     if num_steps is None:
+        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/cnnmrf.lua#L44
         num_steps = 100 if impl_params else 200
 
     if num_levels is None:
+        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/cnnmrf.lua#L43
         num_levels = 3 if impl_params else None
 
     return pyramid.OctaveImagePyramid(

--- a/pystiche_papers/ulyanov_et_al_2016/_data.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_data.py
@@ -207,12 +207,11 @@ def batch_sampler(
 
     if num_batches is None:
         if impl_params:
-            # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L48
             # The num_iterations are split up into multiple epochs with corresponding num_batches:
             # 50000 = 25 * 2000
-            # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L30
-            # The num_iterations are split up into multiple epochs with corresponding num_batches:
+            # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L48
             # 3000 = 10 * 300
+            # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L30
             num_batches = 2000 if instance_norm else 300
         else:
             num_batches = 200

--- a/pystiche_papers/ulyanov_et_al_2016/_data.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_data.py
@@ -207,7 +207,8 @@ def batch_sampler(
 
     if num_batches is None:
         if impl_params:
-            # The num_iterations are split up into multiple epochs with corresponding num_batches:
+            # The num_iterations are split up into multiple epochs with corresponding
+            # num_batches:
             # 50000 = 25 * 2000
             # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L48
             # 3000 = 10 * 300

--- a/pystiche_papers/ulyanov_et_al_2016/_data.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_data.py
@@ -32,8 +32,10 @@ def content_transform(
     transforms_: List[transforms.Transform] = []
     if impl_params:
         if instance_norm:
+            # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/datasets/style.lua#L87
             transforms_.append(transforms.ValidRandomCrop(edge_size))
         else:
+            # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_process.lua#L30
             transforms_.append(
                 transforms.Resize((edge_size, edge_size), interpolation_mode="bilinear")
             )
@@ -47,6 +49,8 @@ def content_transform(
 def style_transform(
     impl_params: bool = True, instance_norm: bool = True, edge_size: int = 256,
 ) -> transforms.Resize:
+    # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L152
+    # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/src/descriptor_net.lua#L17
     interpolation_mode = "bicubic" if impl_params and instance_norm else "bilinear"
     return transforms.Resize(
         edge_size, edge="long", interpolation_mode=interpolation_mode
@@ -200,12 +204,16 @@ def batch_sampler(
 
     if num_batches is None:
         if impl_params:
+            # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L48
+            # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L30
             num_batches = 2000 if instance_norm else 300
         else:
             num_batches = 200
 
     if batch_size is None:
         if impl_params:
+            # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L50
+            # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L32
             batch_size = 1 if instance_norm else 4
         else:
             batch_size = 16

--- a/pystiche_papers/ulyanov_et_al_2016/_data.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_data.py
@@ -32,7 +32,7 @@ def content_transform(
     transforms_: List[transforms.Transform] = []
     if impl_params:
         if instance_norm:
-            # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/datasets/style.lua#L87
+            # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/datasets/style.lua#L83
             transforms_.append(transforms.ValidRandomCrop(edge_size))
         else:
             # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_process.lua#L30
@@ -205,7 +205,13 @@ def batch_sampler(
     if num_batches is None:
         if impl_params:
             # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L48
+            # Due to the use of optim.default_transformer_epoch_optim_loop, the num_iter is the result of
+            # multiplying the number of epochs and the number of batches within an epoch.
+            # 50000 = 25 * 2000
             # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L30
+            # Due to the use of optim.default_transformer_epoch_optim_loop, the num_iter is the result of
+            # multiplying the number of epochs and the number of batches within an epoch.
+            # 3000 = 10 * 300
             num_batches = 2000 if instance_norm else 300
         else:
             num_batches = 200

--- a/pystiche_papers/ulyanov_et_al_2016/_data.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_data.py
@@ -206,9 +206,9 @@ def batch_sampler(
 ) -> FiniteCycleBatchSampler:
 
     if num_batches is None:
+        # The num_iterations are split up into multiple epochs with corresponding
+        # num_batches:
         if impl_params:
-            # The num_iterations are split up into multiple epochs with corresponding
-            # num_batches:
             # 50000 = 25 * 2000
             # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L48
             # 3000 = 10 * 300
@@ -216,6 +216,7 @@ def batch_sampler(
             # The number of epochs is defined in _nst.training .
             num_batches = 2000 if instance_norm else 300
         else:
+            # 2000 = 10 * 200
             num_batches = 200
 
     if batch_size is None:

--- a/pystiche_papers/ulyanov_et_al_2016/_data.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_data.py
@@ -33,9 +33,11 @@ def content_transform(
     if impl_params:
         if instance_norm:
             # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/datasets/style.lua#L83
+            # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/datasets/transforms.lua#L62-L92
             transforms_.append(transforms.ValidRandomCrop(edge_size))
         else:
             # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_process.lua#L30
+            # https://github.com/torch/image/blob/master/doc/simpletransform.md#res-imagescalesrc-width-height-mode
             transforms_.append(
                 transforms.Resize((edge_size, edge_size), interpolation_mode="bilinear")
             )
@@ -51,6 +53,7 @@ def style_transform(
 ) -> transforms.Resize:
     # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L152
     # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/src/descriptor_net.lua#L17
+    # https://github.com/torch/image/blob/master/doc/simpletransform.md#res-imagescalesrc-width-height-mode
     interpolation_mode = "bicubic" if impl_params and instance_norm else "bilinear"
     return transforms.Resize(
         edge_size, edge="long", interpolation_mode=interpolation_mode
@@ -205,12 +208,10 @@ def batch_sampler(
     if num_batches is None:
         if impl_params:
             # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L48
-            # Due to the use of optim.default_transformer_epoch_optim_loop, the num_iter is the result of
-            # multiplying the number of epochs and the number of batches within an epoch.
+            # The num_iterations are split up into multiple epochs with corresponding num_batches:
             # 50000 = 25 * 2000
             # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L30
-            # Due to the use of optim.default_transformer_epoch_optim_loop, the num_iter is the result of
-            # multiplying the number of epochs and the number of batches within an epoch.
+            # The num_iterations are split up into multiple epochs with corresponding num_batches:
             # 3000 = 10 * 300
             num_batches = 2000 if instance_norm else 300
         else:

--- a/pystiche_papers/ulyanov_et_al_2016/_data.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_data.py
@@ -208,12 +208,12 @@ def batch_sampler(
     if num_batches is None:
         # The num_iterations are split up into multiple epochs with corresponding
         # num_batches:
+        # The number of epochs is defined in _nst.training .
         if impl_params:
             # 50000 = 25 * 2000
             # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L48
             # 3000 = 10 * 300
             # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L30
-            # The number of epochs is defined in _nst.training .
             num_batches = 2000 if instance_norm else 300
         else:
             # 2000 = 10 * 200

--- a/pystiche_papers/ulyanov_et_al_2016/_data.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_data.py
@@ -53,7 +53,7 @@ def style_transform(
 ) -> transforms.Resize:
     # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L152
     # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/src/descriptor_net.lua#L17
-    # https://github.com/torch/image/blob/master/doc/simpletransform.md#res-imagescalesrc-width-height-mode
+    # https://github.com/torch/image/blob/master/doc/simpletransform.md#res-imagescalesrc-size-mode
     interpolation_mode = "bicubic" if impl_params and instance_norm else "bilinear"
     return transforms.Resize(
         edge_size, edge="long", interpolation_mode=interpolation_mode
@@ -212,6 +212,7 @@ def batch_sampler(
             # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L48
             # 3000 = 10 * 300
             # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L30
+            # The number of epochs is defined in _nst.training .
             num_batches = 2000 if instance_norm else 300
         else:
             num_batches = 200

--- a/pystiche_papers/ulyanov_et_al_2016/_loss.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_loss.py
@@ -32,14 +32,11 @@ class FeatureReconstructionOperator(ops.FeatureReconstructionOperator):
         if not self.double_batch_size_mean:
             return score
 
-
+        # instance_norm:
+        # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L217
+        # not instance_norm:
+        # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L162
         batch_size = image.extract_batch_size(input_repr)
-        """
-        instance_norm:
-        https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L217
-        not instance_norm:
-        https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L162
-        """
         return score / batch_size
 
 
@@ -52,12 +49,10 @@ def content_loss(
 ) -> FeatureReconstructionOperator:
     if score_weight is None:
         if impl_params:
-            """
-            instance_norm:
-            https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L54
-            not instance_norm:
-            https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L22
-            """
+            # instance_norm:
+            # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L54
+            # not instance_norm:
+            # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L22
             score_weight = 1e0 if instance_norm else 6e-1
         else:
             score_weight = 1e0
@@ -99,12 +94,10 @@ class GramOperator(ops.GramOperator):
             return score
 
         batch_size = input_repr.size()[0]
-        """
-        instance_norm:
-        https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L54
-        not instance_norm:
-        https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L22
-        """
+        # instance_norm:
+        # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L54
+        # not instance_norm:
+        # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L22
         return score / batch_size
 
 

--- a/pystiche_papers/ulyanov_et_al_2016/_loss.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_loss.py
@@ -36,6 +36,8 @@ class FeatureReconstructionOperator(ops.FeatureReconstructionOperator):
         # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L217
         # not instance_norm:
         # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L162
+        # nn.MSECriterion() was used to calculate the content loss, which by default uses reduction="mean" which
+        # also includes the batch_size. However, here again the batch_size is used as an additional division.
         batch_size = image.extract_batch_size(input_repr)
         return score / batch_size
 
@@ -95,9 +97,11 @@ class GramOperator(ops.GramOperator):
 
         batch_size = input_repr.size()[0]
         # instance_norm:
-        # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L54
+        # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L217
         # not instance_norm:
-        # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L22
+        # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L162
+        # nn.MSECriterion() was used to calculate the style loss, which by default uses reduction="mean" which
+        # also includes the batch_size. However, here again the batch_size is used as an additional division.
         return score / batch_size
 
 

--- a/pystiche_papers/ulyanov_et_al_2016/_loss.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_loss.py
@@ -36,8 +36,9 @@ class FeatureReconstructionOperator(ops.FeatureReconstructionOperator):
         # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L217
         # not instance_norm:
         # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L162
-        # nn.MSECriterion() was used to calculate the content loss, which by default uses reduction="mean" which
-        # also includes the batch_size. However, here again the batch_size is used as an additional division.
+        # nn.MSECriterion() was used to calculate the content loss, which by default
+        # uses reduction="mean" which also includes the batch_size. However, here
+        # again the batch_size is used as an additional division.
         batch_size = image.extract_batch_size(input_repr)
         return score / batch_size
 
@@ -71,8 +72,9 @@ class GramOperator(ops.GramOperator):
         self.loss_reduction = "mean"
         # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L217
         # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L162
-        # nn.MSECriterion() was used to calculate the style loss, which by default uses reduction="mean" which
-        # also includes the batch_size. However, here again the batch_size is used as an additional division.
+        # nn.MSECriterion() was used to calculate the style loss, which by default uses
+        # reduction="mean" which also includes the batch_size. However, here again the
+        # batch_size is used as an additional division.
         self.double_batch_size_mean = impl_params
 
     def enc_to_repr(self, enc: torch.Tensor) -> torch.Tensor:

--- a/pystiche_papers/ulyanov_et_al_2016/_loss.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_loss.py
@@ -69,6 +69,10 @@ class GramOperator(ops.GramOperator):
         super().__init__(encoder, **gram_op_kwargs)
         self.normalize_by_num_channels = impl_params
         self.loss_reduction = "mean"
+        # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L217
+        # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L162
+        # nn.MSECriterion() was used to calculate the style loss, which by default uses reduction="mean" which
+        # also includes the batch_size. However, here again the batch_size is used as an additional division.
         self.double_batch_size_mean = impl_params
 
     def enc_to_repr(self, enc: torch.Tensor) -> torch.Tensor:
@@ -90,12 +94,6 @@ class GramOperator(ops.GramOperator):
             return score
 
         batch_size = input_repr.size()[0]
-        # instance_norm:
-        # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L217
-        # not instance_norm:
-        # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L162
-        # nn.MSECriterion() was used to calculate the style loss, which by default uses reduction="mean" which
-        # also includes the batch_size. However, here again the batch_size is used as an additional division.
         return score / batch_size
 
 

--- a/pystiche_papers/ulyanov_et_al_2016/_loss.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_loss.py
@@ -50,14 +50,8 @@ def content_loss(
     score_weight: Optional[float] = None,
 ) -> FeatureReconstructionOperator:
     if score_weight is None:
-        if impl_params:
-            # instance_norm:
-            # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L54
-            # not instance_norm:
-            # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L22
-            score_weight = 1e0 if instance_norm else 6e-1
-        else:
-            score_weight = 1e0
+        # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L22
+        score_weight = 6e-1 if impl_params and not instance_norm else 1e0
 
     if multi_layer_encoder is None:
         multi_layer_encoder = _multi_layer_encoder()
@@ -115,7 +109,6 @@ def style_loss(
     **gram_op_kwargs: Any,
 ) -> ops.MultiLayerEncodingOperator:
     if score_weight is None:
-        # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L55
         # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L23
         score_weight = 1e3 if impl_params and not instance_norm else 1e0
 
@@ -127,7 +120,6 @@ def style_loss(
             # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L44
             layers = ("relu1_1", "relu2_1", "relu3_1", "relu4_1")
         else:
-            # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L19
             layers = ("relu1_1", "relu2_1", "relu3_1", "relu4_1", "relu5_1")
 
     def get_encoding_op(encoder: enc.Encoder, layer_weight: float) -> GramOperator:

--- a/pystiche_papers/ulyanov_et_al_2016/_loss.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_loss.py
@@ -37,8 +37,8 @@ class FeatureReconstructionOperator(ops.FeatureReconstructionOperator):
         # not instance_norm:
         # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L162
         # nn.MSECriterion() was used to calculate the content loss, which by default
-        # uses reduction="mean" which also includes the batch_size. However, here
-        # again the batch_size is used as an additional division.
+        # uses reduction="mean" which also includes the batch_size. However, the
+        # score is divided once more by the batch_size in the reference implementation.
         batch_size = image.extract_batch_size(input_repr)
         return score / batch_size
 
@@ -73,8 +73,8 @@ class GramOperator(ops.GramOperator):
         # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L217
         # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L162
         # nn.MSECriterion() was used to calculate the style loss, which by default uses
-        # reduction="mean" which also includes the batch_size. However, here again the
-        # batch_size is used as an additional division.
+        # uses reduction="mean" which also includes the batch_size. However, the
+        # score is divided once more by the batch_size in the reference implementation.
         self.double_batch_size_mean = impl_params
 
     def enc_to_repr(self, enc: torch.Tensor) -> torch.Tensor:

--- a/pystiche_papers/ulyanov_et_al_2016/_loss.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_loss.py
@@ -32,7 +32,14 @@ class FeatureReconstructionOperator(ops.FeatureReconstructionOperator):
         if not self.double_batch_size_mean:
             return score
 
+
         batch_size = image.extract_batch_size(input_repr)
+        """
+        instance_norm:
+        https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L217
+        not instance_norm:
+        https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L162
+        """
         return score / batch_size
 
 
@@ -45,6 +52,12 @@ def content_loss(
 ) -> FeatureReconstructionOperator:
     if score_weight is None:
         if impl_params:
+            """
+            instance_norm:
+            https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L54
+            not instance_norm:
+            https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L22
+            """
             score_weight = 1e0 if instance_norm else 6e-1
         else:
             score_weight = 1e0
@@ -86,6 +99,12 @@ class GramOperator(ops.GramOperator):
             return score
 
         batch_size = input_repr.size()[0]
+        """
+        instance_norm:
+        https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L54
+        not instance_norm:
+        https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L22
+        """
         return score / batch_size
 
 
@@ -99,15 +118,20 @@ def style_loss(
     **gram_op_kwargs: Any,
 ) -> ops.MultiLayerEncodingOperator:
     if score_weight is None:
+        # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L55
+        # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L23
         score_weight = 1e3 if impl_params and not instance_norm else 1e0
+
 
     if multi_layer_encoder is None:
         multi_layer_encoder = _multi_layer_encoder()
 
     if layers is None:
         if impl_params and instance_norm:
+            # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L44
             layers = ("relu1_1", "relu2_1", "relu3_1", "relu4_1")
         else:
+            # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L19
             layers = ("relu1_1", "relu2_1", "relu3_1", "relu4_1", "relu5_1")
 
     def get_encoding_op(encoder: enc.Encoder, layer_weight: float) -> GramOperator:

--- a/pystiche_papers/ulyanov_et_al_2016/_loss.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_loss.py
@@ -119,7 +119,6 @@ def style_loss(
         # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L23
         score_weight = 1e3 if impl_params and not instance_norm else 1e0
 
-
     if multi_layer_encoder is None:
         multi_layer_encoder = _multi_layer_encoder()
 

--- a/pystiche_papers/ulyanov_et_al_2016/_modules.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_modules.py
@@ -283,7 +283,8 @@ class Transformer(nn.Sequential):
             )
 
         if impl_params:
-            # Just a torch.nn.Conv2d is used instead of the ConvBlock as described in the paper.
+            # Just a torch.nn.Conv2d is used instead of the ConvBlock as described in
+            # the paper.
             # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/models/pyramid.lua#L61
             # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/models/pyramid.lua#L62
             output_conv = cast(

--- a/pystiche_papers/ulyanov_et_al_2016/_modules.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_modules.py
@@ -283,6 +283,8 @@ class Transformer(nn.Sequential):
             )
 
         if impl_params:
+            # Just a torch. nn. Conv2D is used instead of the ConBlock consisting of torch. nn Conv2D,
+            # norm module and activation function as described in the paper.
             # instance_norm:
             # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/models/pyramid.lua#L61
             # not instance_norm:
@@ -341,5 +343,4 @@ def transformer(
     levels: int = 6,
 ) -> Transformer:
     return Transformer(levels, impl_params=impl_params, instance_norm=instance_norm)
-
 

--- a/pystiche_papers/ulyanov_et_al_2016/_modules.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_modules.py
@@ -77,6 +77,7 @@ def norm(
 def activation(
     impl_params: bool, instance_norm: bool, inplace: bool = True
 ) -> nn.Module:
+    # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/models/pyramid.lua#L5
     return (
         nn.ReLU(inplace=inplace)
         if impl_params and instance_norm
@@ -282,6 +283,12 @@ class Transformer(nn.Sequential):
             )
 
         if impl_params:
+            """
+            instance_norm:
+            https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/models/pyramid.lua#L61
+            not instance_norm:
+            https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/models/pyramid.lua#L62
+            """
             output_conv = cast(
                 Union[nn.Conv2d, ConvBlock],
                 nn.Conv2d(
@@ -336,3 +343,4 @@ def transformer(
     levels: int = 6,
 ) -> Transformer:
     return Transformer(levels, impl_params=impl_params, instance_norm=instance_norm)
+

--- a/pystiche_papers/ulyanov_et_al_2016/_modules.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_modules.py
@@ -343,4 +343,3 @@ def transformer(
     levels: int = 6,
 ) -> Transformer:
     return Transformer(levels, impl_params=impl_params, instance_norm=instance_norm)
-

--- a/pystiche_papers/ulyanov_et_al_2016/_modules.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_modules.py
@@ -283,11 +283,8 @@ class Transformer(nn.Sequential):
             )
 
         if impl_params:
-            # Just a torch. nn. Conv2D is used instead of the ConBlock consisting of torch. nn Conv2D,
-            # norm module and activation function as described in the paper.
-            # instance_norm:
+            # Just a torch.nn.Conv2d is used instead of the ConvBlock as described in the paper.
             # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/models/pyramid.lua#L61
-            # not instance_norm:
             # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/models/pyramid.lua#L62
             output_conv = cast(
                 Union[nn.Conv2d, ConvBlock],

--- a/pystiche_papers/ulyanov_et_al_2016/_modules.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_modules.py
@@ -283,12 +283,10 @@ class Transformer(nn.Sequential):
             )
 
         if impl_params:
-            """
-            instance_norm:
-            https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/models/pyramid.lua#L61
-            not instance_norm:
-            https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/models/pyramid.lua#L62
-            """
+            # instance_norm:
+            # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/models/pyramid.lua#L61
+            # not instance_norm:
+            # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/models/pyramid.lua#L62
             output_conv = cast(
                 Union[nn.Conv2d, ConvBlock],
                 nn.Conv2d(
@@ -343,4 +341,5 @@ def transformer(
     levels: int = 6,
 ) -> Transformer:
     return Transformer(levels, impl_params=impl_params, instance_norm=instance_norm)
+
 

--- a/pystiche_papers/ulyanov_et_al_2016/_nst.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_nst.py
@@ -73,8 +73,6 @@ def training(
         # num_batches:
         # 50000 = 25 * 2000
         # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L48
-        # The num_iterations are split up into multiple epochs with corresponding
-        # num_batches:
         # 3000 = 10 * 300
         # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L30
         # The num_batches is defined in ._data.batch_sampler .

--- a/pystiche_papers/ulyanov_et_al_2016/_nst.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_nst.py
@@ -70,12 +70,10 @@ def training(
 
     if num_epochs is None:
         # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L48
-        # Due to the use of optim.default_transformer_epoch_optim_loop, the num_iter is the result of
-        # multiplying the number of epochs and the number of batches within an epoch.
+        # The num_iterations are split up into multiple epochs with corresponding num_batches:
         # 50000 = 25 * 2000
         # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L30
-        # Due to the use of optim.default_transformer_epoch_optim_loop, the num_iter is the result of
-        # multiplying the number of epochs and the number of batches within an epoch.
+        # The num_iterations are split up into multiple epochs with corresponding num_batches:
         # 3000 = 10 * 300
         num_epochs = 25 if impl_params and instance_norm else 10
 

--- a/pystiche_papers/ulyanov_et_al_2016/_nst.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_nst.py
@@ -69,12 +69,13 @@ def training(
         lr_scheduler = _lr_scheduler(optimizer_, impl_params=impl_params,)
 
     if num_epochs is None:
-        # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L48
         # The num_iterations are split up into multiple epochs with corresponding num_batches:
         # 50000 = 25 * 2000
-        # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L30
+        # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L48
         # The num_iterations are split up into multiple epochs with corresponding num_batches:
         # 3000 = 10 * 300
+        # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L30
+        # The num_batches is defined in ._data.batch_sampler .
         num_epochs = 25 if impl_params and instance_norm else 10
 
     style_transform = _style_transform(

--- a/pystiche_papers/ulyanov_et_al_2016/_nst.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_nst.py
@@ -70,7 +70,13 @@ def training(
 
     if num_epochs is None:
         # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L48
+        # Due to the use of optim.default_transformer_epoch_optim_loop, the num_iter is the result of
+        # multiplying the number of epochs and the number of batches within an epoch.
+        # 50000 = 25 * 2000
         # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L30
+        # Due to the use of optim.default_transformer_epoch_optim_loop, the num_iter is the result of
+        # multiplying the number of epochs and the number of batches within an epoch.
+        # 3000 = 10 * 300
         num_epochs = 25 if impl_params and instance_norm else 10
 
     style_transform = _style_transform(

--- a/pystiche_papers/ulyanov_et_al_2016/_nst.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_nst.py
@@ -69,6 +69,8 @@ def training(
         lr_scheduler = _lr_scheduler(optimizer_, impl_params=impl_params,)
 
     if num_epochs is None:
+        # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L48
+        # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L30
         num_epochs = 25 if impl_params and instance_norm else 10
 
     style_transform = _style_transform(
@@ -113,6 +115,7 @@ def stylization(
             style=style, impl_params=impl_params, instance_norm=instance_norm,
         )
         if instance_norm or not impl_params:
+            # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/test.lua#L32
             transformer = transformer.eval()
     transformer = transformer.to(device)
 

--- a/pystiche_papers/ulyanov_et_al_2016/_nst.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_nst.py
@@ -69,10 +69,12 @@ def training(
         lr_scheduler = _lr_scheduler(optimizer_, impl_params=impl_params,)
 
     if num_epochs is None:
-        # The num_iterations are split up into multiple epochs with corresponding num_batches:
+        # The num_iterations are split up into multiple epochs with corresponding
+        # num_batches:
         # 50000 = 25 * 2000
         # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L48
-        # The num_iterations are split up into multiple epochs with corresponding num_batches:
+        # The num_iterations are split up into multiple epochs with corresponding
+        # num_batches:
         # 3000 = 10 * 300
         # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L30
         # The num_batches is defined in ._data.batch_sampler .

--- a/pystiche_papers/ulyanov_et_al_2016/_utils.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_utils.py
@@ -34,9 +34,6 @@ def postprocessor() -> transforms.CaffePostprocessing:
 def optimizer(
     transformer: nn.Module, impl_params: bool = True, instance_norm: bool = True
 ) -> optim.Adam:
-    # instance_norm:
-    # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L46
-    # not instance_norm:
     # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L29
     lr = 1e-3 if impl_params and instance_norm else 1e-1
     return optim.Adam(transformer.parameters(), lr=lr)

--- a/pystiche_papers/ulyanov_et_al_2016/_utils.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_utils.py
@@ -34,6 +34,10 @@ def postprocessor() -> transforms.CaffePostprocessing:
 def optimizer(
     transformer: nn.Module, impl_params: bool = True, instance_norm: bool = True
 ) -> optim.Adam:
+    # instance_norm:
+    # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L46
+    # not instance_norm:
+    # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L29
     lr = 1e-3 if impl_params and instance_norm else 1e-1
     return optim.Adam(transformer.parameters(), lr=lr)
 
@@ -58,8 +62,13 @@ class DelayedExponentialLR(ExponentialLR):
 
 
 def lr_scheduler(optimizer: Optimizer, impl_params: bool = True,) -> ExponentialLR:
+    # instance_norm:
+    # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L260
+    # not instance_norm:
+    # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L201
     return (
         ExponentialLR(optimizer, 0.8)
         if impl_params
         else DelayedExponentialLR(optimizer, 0.7, 5)
     )
+

--- a/pystiche_papers/ulyanov_et_al_2016/_utils.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_utils.py
@@ -59,9 +59,7 @@ class DelayedExponentialLR(ExponentialLR):
 
 
 def lr_scheduler(optimizer: Optimizer, impl_params: bool = True,) -> ExponentialLR:
-    # instance_norm:
     # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L260
-    # not instance_norm:
     # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L201
     return (
         ExponentialLR(optimizer, 0.8)

--- a/pystiche_papers/ulyanov_et_al_2016/_utils.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_utils.py
@@ -71,4 +71,3 @@ def lr_scheduler(optimizer: Optimizer, impl_params: bool = True,) -> Exponential
         if impl_params
         else DelayedExponentialLR(optimizer, 0.7, 5)
     )
-


### PR DESCRIPTION
Adding permalinks to the respective reference implementation parameters from the respective papers. Currently the permalinks are only added as a comment, do you have an idea how they can be better integrated? This is especially for those papers where the combination of `instance_norm` and `impl_params` is important.

For Example:
```python
"""
instance_norm:
https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/models/pyramid.lua#L3
not instance_norm:
https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/models/pyramid.lua#L3
"""
```

In Addition:
The permalinks of the `impl_params` setting of the pre-trained styles from the paper johnson_alahi_li_2016 are still missing