### PR TITLE
partially fix hub tests for PRs

### DIFF
--- a/tests/hub/conftest.py
+++ b/tests/hub/conftest.py
@@ -8,14 +8,17 @@ from torch import hub
 @pytest.fixture(scope="package")
 def github():
     if os.getenv("GITHUB_ACTIONS"):
-        owner_and_repo = os.getenv("GITHUB_REPOSITORY")
+        # FIXME: this environment variable does not contain the owner of the repository
+        #  but rather the person who triggered the workflow.
+        #  See https://github.com/pmeier/pystiche_papers/issues/116 for details
+        owner = os.getenv("GITHUB_ACTOR")
 
         branch_or_tag = os.getenv("GITHUB_HEAD_REF")
         is_pr = bool(branch_or_tag)
         if not is_pr:
             branch_or_tag = os.getenv("GITHUB_REF").rsplit("/", 1)[1]
 
-        return f"{owner_and_repo}:{branch_or_tag}"
+        return f"{owner}/pystiche_papers:{branch_or_tag}"
     else:
         return os.getenv("PYSTICHE_HUB_GITHUB", default="pmeier/pystiche_papers:master")
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
 passenv =
   PYSTICHE_HUB_GITHUB
   GITHUB_ACTIONS
-  GITHUB_REPOSITORY
+  GITHUB_ACTOR
   GITHUB_HEAD_REF
   GITHUB_REF
 deps = {[tests-common]deps}


### PR DESCRIPTION
Adresses #116. This enables hub tests from within a PR from a fork. Nevertheless, this will still fail if someone adds commits to branch that is not part of his own fork.