### PR TITLE
Fix warning message in DelayedExponentialLR

### DIFF
--- a/tests/unit/ulyanov_et_al_2016/test_utils.py
+++ b/tests/unit/ulyanov_et_al_2016/test_utils.py
@@ -79,6 +79,7 @@ def test_DelayedExponentialLR():
 
         param_group = optimizer.param_groups[0]
         assert param_group["lr"] == ptu.approx(base_lr)
+        optimizer.step()
         lr_scheduler.step()
 
 


### PR DESCRIPTION
Fix the warning message mentioned in [#114](https://github.com/pmeier/pystiche_papers/issues/114).