### PR TITLE
Add docs for ulyanov_et_al_2016 modules

### DIFF
--- a/docs/source/api/pystiche_papers.ulyanov_et_al_2016.rst
+++ b/docs/source/api/pystiche_papers.ulyanov_et_al_2016.rst
@@ -61,7 +61,7 @@ The following table provides an overview of the parameters:
 
   - the :func:`~pystiche_papers.ulyanov_et_al_2016.style_loss`.
 
-The ``layers`` have either configuration ``1``
+The ``style_layers`` have either configuration ``1``
 ``("relu1_1", "relu2_1", "relu3_1", "relu4_1")`` or  configuration ``2``
 ``("relu1_1", "relu2_1", "relu3_1", "relu4_1", "relu5_1")``.
 
@@ -83,6 +83,7 @@ The ``layers`` have either configuration ``1``
 +---------------------------+-------------+---------------------+
 | ``style_layers``          | ``1``       | ``2``               |
 +---------------------------+-------------+---------------------+
+
 
 .. automodule:: pystiche_papers.ulyanov_et_al_2016
 

--- a/docs/source/api/pystiche_papers.ulyanov_et_al_2016.rst
+++ b/docs/source/api/pystiche_papers.ulyanov_et_al_2016.rst
@@ -84,7 +84,6 @@ The ``layers`` have either configuration ``1``
 | ``style_layers``          | ``1``       | ``2``               |
 +---------------------------+-------------+---------------------+
 
-
 .. automodule:: pystiche_papers.ulyanov_et_al_2016
 
 .. autofunction:: batch_sampler

--- a/pystiche_papers/ulyanov_et_al_2016/_modules.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_modules.py
@@ -16,6 +16,13 @@ def join_channelwise(*inputs: torch.Tensor, channel_dim: int = 1) -> torch.Tenso
 
 
 class AddNoiseChannels(nn.Module):
+    r"""Adds noise channels in the size of the input to the input.
+
+    Args:
+        in_channels: Number of input channels.
+        num_noise_channels: Number of additional noise channels. Defaults to 3.
+    """
+
     def __init__(
         self, in_channels: int, num_noise_channels: int = 3,
     ):
@@ -49,6 +56,12 @@ def upsample() -> nn.Upsample:
 
 
 class HourGlassBlock(SequentialWithOutChannels):
+    r"""HourGlassBlock from :cite:`ULVL2016`.
+
+    Args:
+        intermediate: Middle :class:`~torch.nn.Module` of the block.
+    """
+
     def __init__(self, intermediate: nn.Module):
         modules = (
             ("down", downsample()),
@@ -86,6 +99,24 @@ def activation(
 
 
 class ConvBlock(SequentialWithOutChannels):
+    r"""ConvBlock from :cite:`ULVL2016`.
+
+    Args:
+        in_channels: Number of channels in the input.
+        out_channels:  Number of channels produced by the convolution.
+        kernel_size: Size of the convolving kernel.
+        impl_params: If ``True``, use the parameters used in the reference
+            implementation of the original authors rather than what is described in
+            the paper. For details see FIXME.
+        stride: Stride of the convolution. Defaults to 1.
+        instance_norm: If ``True``, use :class:`~torch.nn.InstanceNorm2d` rather than
+            :class:`~torch.nn.BatchNorm2d` as described in the paper. Additionally this
+            flag is used for switching between the github branches. For details see
+            FIXME.
+        inplace: Can optionally do the operation in-place. Defaults to ``True``.
+
+    """
+
     def __init__(
         self,
         in_channels: int,
@@ -120,6 +151,22 @@ class ConvBlock(SequentialWithOutChannels):
 
 
 class ConvSequence(SequentialWithOutChannels):
+    r"""Sequence of convolutional blocks that occurs repeatedly in :cite:`ULVL2016`.
+
+    Args:
+        in_channels: Number of channels in the input.
+        out_channels: Number of channels produced by the convolution
+        impl_params: If ``True``, use the parameters used in the reference
+            implementation of the original authors rather than what is described in
+            the paper. For details see FIXME.
+        instance_norm: If ``True``, use :class:`~torch.nn.InstanceNorm2d` rather than
+            :class:`~torch.nn.BatchNorm2d` as described in the paper. Additionally this
+            flag is used for switching between the github branches. For details see
+            FIXME.
+        inplace: Can optionally do the operation in-place. Defaults to ``True``.
+
+    """
+
     def __init__(
         self,
         in_channels: int,
@@ -150,6 +197,20 @@ class ConvSequence(SequentialWithOutChannels):
 
 
 class JoinBlock(nn.Module):
+    r"""JoinBlock from :cite:`ULVL2016`.
+
+    Args:
+        branch_in_channels: Number of channels in the branch input.
+        names: Optional names for the blocks. If omitted, the blocks are numbered.
+        instance_norm: If ``True``, use :class:`~torch.nn.InstanceNorm2d` rather than
+            :class:`~torch.nn.BatchNorm2d` as described in the paper. Additionally this
+            flag is used for switching between the github branches. For details see
+            FIXME.
+        channel_dim: The dimension over which the tensors are concatenated. Defaults to
+            1.
+
+    """
+
     def __init__(
         self,
         branch_in_channels: Sequence[int],
@@ -188,6 +249,17 @@ class JoinBlock(nn.Module):
 
 
 class BranchBlock(nn.Module):
+    r"""BranchBlock from :cite:`ULVL2016`.
+
+    Args:
+        deep_branch: Input from the branch one step deeper in the pyramid.
+        shallow_branch: Input from the current branch.
+        instance_norm: If ``True``, use :class:`~torch.nn.InstanceNorm2d` rather than
+            :class:`~torch.nn.BatchNorm2d` as described in the paper. Additionally this
+            flag is used for switching between the github branches. For details see
+            FIXME.
+    """
+
     def __init__(
         self,
         deep_branch: nn.Module,
@@ -224,6 +296,24 @@ def level(
     num_noise_channels: int = 3,
     inplace: bool = True,
 ) -> SequentialWithOutChannels:
+    r"""Defines one level of the Transformer from :cite:`ULVL2016`.
+
+    Args:
+        prev_level_block: Optional Input from the previous level. If ``None``, only one
+            ConvSequence is returned.
+        impl_params: If ``True``, use the parameters used in the reference
+            implementation of the original authors rather than what is described in
+            the paper. For details see FIXME.
+        instance_norm: If ``True``, use :class:`~torch.nn.InstanceNorm2d` rather than
+            :class:`~torch.nn.BatchNorm2d` as described in the paper. Additionally this
+            flag is used for switching between the github branches. For details see
+            FIXME.
+        in_channels: Number of channels in the input image. Defaults to 3.
+        num_noise_channels: Number of additional noise channels. Defaults to 3.
+        inplace: Can optionally do the operation in-place. Defaults to ``True``.
+
+    """
+
     def conv_sequence(
         in_channels: int, out_channels: int, use_noise: bool = False
     ) -> SequentialWithOutChannels:
@@ -340,4 +430,18 @@ def transformer(
     instance_norm: bool = True,
     levels: int = 6,
 ) -> Transformer:
+    r"""Initialized the Transformer from :cite:`ULVL2016`.
+
+    Args:
+        style: FIXME this should be removed.
+        impl_params: If ``True``, use the parameters used in the reference
+            implementation of the original authors rather than what is described in
+            the paper. For details see FIXME.
+        instance_norm: If ``True``, use :class:`~torch.nn.InstanceNorm2d` rather than
+            :class:`~torch.nn.BatchNorm2d` as described in the paper. Additionally this
+            flag is used for switching between the github branches. For details see
+            FIXME.
+        levels: Number of levels in the Transformer. Defaults to 6.
+
+    """
     return Transformer(levels, impl_params=impl_params, instance_norm=instance_norm)

--- a/pystiche_papers/ulyanov_et_al_2016/_modules.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_modules.py
@@ -276,12 +276,12 @@ class JoinBlock(nn.Module):
 class BranchBlock(nn.Module):
     r"""BranchBlock from :cite:`ULVL2016`.
 
-    This block combines the ``deep_branch`` with the ``shallow_branch`` using a
+    Joins the branch from the previous pyramid with the current level using a
     :class:`~pystiche_paper.ulyanov_et_al_2016._modules.JoinBlock`.
 
     Args:
-        deep_branch: Input from the branch one step deeper in the pyramid.
-        shallow_branch: Input from the current branch.
+        deep_branch: Input from the previous pyramid.
+        shallow_branch: Input from the current level.
         instance_norm: If ``True``, use :class:`~torch.nn.InstanceNorm2d` rather than
             :class:`~torch.nn.BatchNorm2d` as described in the paper. Additionally this
             flag is used for switching between two reference implementations. For

--- a/pystiche_papers/ulyanov_et_al_2016/_modules.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_modules.py
@@ -58,6 +58,10 @@ def upsample() -> nn.Upsample:
 class HourGlassBlock(SequentialWithOutChannels):
     r"""HourGlassBlock from :cite:`ULVL2016`.
 
+    This block comprises a downsample to half the size using
+    :class:`~torch.nn.AvgPool2d` followed by a processing with ``intermediate`` and an
+    upsample to twice the size using :class:`~torch.nn.Upsample`.
+
     Args:
         intermediate: Module in between the down- and upsampling.
 
@@ -329,10 +333,10 @@ def level(
 ) -> SequentialWithOutChannels:
     r"""Defines one level of the transformer from :cite:`ULVL2016`.
 
-    The basic building block of a level is a :class:`ConvSequence` . If a previous 
-    level exists, i. e. the current level is not the first one, the previous level is 
-    incorporated by embedding it in an :class:`HourGlassBlock`. The outputs of both 
-    levels are joined with a :class:`BranchBlock` and finally fed through another 
+    The basic building block of a level is a :class:`ConvSequence` . If a previous
+    level exists, i. e. the current level is not the first one, the previous level is
+    incorporated by embedding it in an :class:`HourGlassBlock`. The outputs of both
+    levels are joined with a :class:`BranchBlock` and finally fed through another
     :class:`ConvSequence`.
 
     Args:

--- a/pystiche_papers/ulyanov_et_al_2016/_modules.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_modules.py
@@ -58,9 +58,11 @@ def upsample() -> nn.Upsample:
 class HourGlassBlock(SequentialWithOutChannels):
     r"""HourGlassBlock from :cite:`ULVL2016`.
 
-    This block comprises a downsample to half the size using
-    :class:`~torch.nn.AvgPool2d` followed by a processing with ``intermediate`` and an
-    upsample to twice the size using :class:`~torch.nn.Upsample`.
+    This block comprises a
+    :func:`~pystiche_paper.ulyanov_et_al_2016._modules.downsample`  to half the size
+    using :class:`~torch.nn.AvgPool2d` followed by a processing with ``intermediate``
+    and an :func:`~pystiche_paper.ulyanov_et_al_2016._modules.upsample` to twice the
+    size using :class:`~torch.nn.Upsample`.
 
     Args:
         intermediate: Module in between the down- and upsampling.

--- a/pystiche_papers/ulyanov_et_al_2016/_modules.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_modules.py
@@ -113,7 +113,7 @@ class ConvBlock(SequentialWithOutChannels):
             :class:`~torch.nn.BatchNorm2d` as described in the paper. Additionally this
             flag is used for switching between the github branches. For details see
             FIXME.
-        inplace: Can optionally do the operation in-place. Defaults to ``True``.
+        inplace: If ``True`` perform the activation in-place.
 
     The parameters ``kernel_size`` and ``stride`` can either be:
 
@@ -303,7 +303,7 @@ def level(
     num_noise_channels: int = 3,
     inplace: bool = True,
 ) -> SequentialWithOutChannels:
-    r"""Defines one level of the Transformer from :cite:`ULVL2016`.
+    r"""Defines one level of the transformer from :cite:`ULVL2016`.
 
     Args:
         prev_level_block: Optional Input from the previous level. If ``None``, only one
@@ -440,7 +440,6 @@ def transformer(
     r"""Transformer from :cite:`ULVL2016`.
 
     Args:
-        style: FIXME this should be removed.
         impl_params: If ``True``, use the parameters used in the reference
             implementation of the original authors rather than what is described in
             the paper. For details see FIXME.
@@ -448,7 +447,7 @@ def transformer(
             :class:`~torch.nn.BatchNorm2d` as described in the paper. Additionally this
             flag is used for switching between the github branches. For details see
             FIXME.
-        levels: Number of levels in the Transformer. Defaults to ``6``.
+        levels: Number of levels in the transformer. Defaults to ``6``.
 
     """
     return Transformer(levels, impl_params=impl_params, instance_norm=instance_norm)

--- a/pystiche_papers/ulyanov_et_al_2016/_modules.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_modules.py
@@ -105,7 +105,7 @@ def activation(
 class ConvBlock(SequentialWithOutChannels):
     r"""ConvBlock from :cite:`ULVL2016`.
 
-    This block contains a convolution followed by normalization and activation. The
+    This block comprises a convolution followed by normalization and activation. The
     input is reflection-padded to preserve the size.
 
     Args:
@@ -173,8 +173,8 @@ class ConvSequence(SequentialWithOutChannels):
     r"""Sequence of convolutional blocks that occurs repeatedly in :cite:`ULVL2016`.
 
     Each sequence contains three
-    :class:`~pystiche_paper.ulyanov_et_al_2016._modules.ConvBlock` blocks while the
-    first two uses ``kernel_size == 3``, the last one uses ``kernel_size == 1``.
+    :class:`~pystiche_paper.ulyanov_et_al_2016._modules.ConvBlock` s. The
+    first two use ``kernel_size == 3`` and the third one uses ``kernel_size == 1``.
 
     Args:
         in_channels: Number of channels in the input.
@@ -329,16 +329,15 @@ def level(
 ) -> SequentialWithOutChannels:
     r"""Defines one level of the transformer from :cite:`ULVL2016`.
 
-    A level contains :class:`~pystiche_paper.ulyanov_et_al_2016._modules.ConvSequence`
-    if it is the first level otherwise the ``prev_level_block`` is put into
-    :class:`~pystiche_paper.ulyanov_et_al_2016._modules.HourGlassBlock` and joined with
-    a :class:`~pystiche_paper.ulyanov_et_al_2016._modules.BranchBlock` and finally
-    followed by another
-    :class:`~pystiche_paper.ulyanov_et_al_2016._modules.ConvSequence`.
+    The basic building block of a level is a :class:`ConvSequence` . If a previous 
+    level exists, i. e. the current level is not the first one, the previous level is 
+    incorporated by embedding it in an :class:`HourGlassBlock`. The outputs of both 
+    levels are joined with a :class:`BranchBlock` and finally fed through another 
+    :class:`ConvSequence`.
 
     Args:
         prev_level_block: Previous pyramid level. If given, it is incorporated in the
-            current level. ConvSequence is returned.
+            current level.
         impl_params: If ``True``, use the parameters used in the reference
             implementation of the original authors rather than what is described in
             the paper. For details see

--- a/pystiche_papers/ulyanov_et_al_2016/_modules.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_modules.py
@@ -20,7 +20,7 @@ class AddNoiseChannels(nn.Module):
 
     Args:
         in_channels: Number of input channels.
-        num_noise_channels: Number of additional noise channels. Defaults to 3.
+        num_noise_channels: Number of additional noise channels. Defaults to ``3``.
     """
 
     def __init__(
@@ -108,12 +108,19 @@ class ConvBlock(SequentialWithOutChannels):
         impl_params: If ``True``, use the parameters used in the reference
             implementation of the original authors rather than what is described in
             the paper. For details see FIXME.
-        stride: Stride of the convolution. Defaults to 1.
+        stride: Stride of the convolution. Defaults to ``1``.
         instance_norm: If ``True``, use :class:`~torch.nn.InstanceNorm2d` rather than
             :class:`~torch.nn.BatchNorm2d` as described in the paper. Additionally this
             flag is used for switching between the github branches. For details see
             FIXME.
         inplace: Can optionally do the operation in-place. Defaults to ``True``.
+
+    The parameters ``kernel_size`` and ``stride`` can either be:
+
+    * a single :class:`int` – in which case the same value is used for the height and
+      width dimension
+    * a tuple of two :class:`int` s – in which case, the first int is used for the
+      vertical dimension, and the second int for the horizontal dimension
 
     """
 
@@ -207,7 +214,7 @@ class JoinBlock(nn.Module):
             flag is used for switching between the github branches. For details see
             FIXME.
         channel_dim: The dimension over which the tensors are concatenated. Defaults to
-            1.
+            ``1``.
 
     """
 
@@ -308,8 +315,8 @@ def level(
             :class:`~torch.nn.BatchNorm2d` as described in the paper. Additionally this
             flag is used for switching between the github branches. For details see
             FIXME.
-        in_channels: Number of channels in the input image. Defaults to 3.
-        num_noise_channels: Number of additional noise channels. Defaults to 3.
+        in_channels: Number of channels in the input image. Defaults to ``3``.
+        num_noise_channels: Number of additional noise channels. Defaults to ``3``.
         inplace: Can optionally do the operation in-place. Defaults to ``True``.
 
     """
@@ -430,7 +437,7 @@ def transformer(
     instance_norm: bool = True,
     levels: int = 6,
 ) -> Transformer:
-    r"""Initialized the Transformer from :cite:`ULVL2016`.
+    r"""Transformer from :cite:`ULVL2016`.
 
     Args:
         style: FIXME this should be removed.
@@ -441,7 +448,7 @@ def transformer(
             :class:`~torch.nn.BatchNorm2d` as described in the paper. Additionally this
             flag is used for switching between the github branches. For details see
             FIXME.
-        levels: Number of levels in the Transformer. Defaults to 6.
+        levels: Number of levels in the Transformer. Defaults to ``6``.
 
     """
     return Transformer(levels, impl_params=impl_params, instance_norm=instance_norm)

--- a/pystiche_papers/ulyanov_et_al_2016/_modules.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_modules.py
@@ -59,9 +59,9 @@ class HourGlassBlock(SequentialWithOutChannels):
     r"""HourGlassBlock from :cite:`ULVL2016`.
 
     This block comprises a
-    :func:`~pystiche_paper.ulyanov_et_al_2016._modules.downsample`  to half the size
+    :func:`downsample`  to half the size
     using :class:`~torch.nn.AvgPool2d` followed by a processing with ``intermediate``
-    and an :func:`~pystiche_paper.ulyanov_et_al_2016._modules.upsample` to twice the
+    and an :func:`upsample` to twice the
     size using :class:`~torch.nn.Upsample`.
 
     Args:

--- a/pystiche_papers/ulyanov_et_al_2016/_modules.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_modules.py
@@ -48,21 +48,27 @@ def noise(in_channels: int = 3, num_noise_channels: int = 3,) -> AddNoiseChannel
 
 
 def downsample(kernel_size: int = 2, stride: int = 2, padding: int = 0) -> nn.AvgPool2d:
+    r"""Downsample the input to half the size using an :class:`~torch.nn.AvgPool2d`.
+
+    Args:
+        kernel_size: Size of the kernel. Defaults to ``2``.
+        stride: Stride of the kernel. Defaults to ``2``.
+        padding: Padding to be added on both sides. Defaults to ``0``.
+
+    """
     return nn.AvgPool2d(kernel_size, stride=stride, padding=padding)
 
 
 def upsample() -> nn.Upsample:
+    r"""Upsample the input to twice the size using an :class:`~torch.nn.Upsample`."""
     return nn.Upsample(scale_factor=2.0, mode="nearest")
 
 
 class HourGlassBlock(SequentialWithOutChannels):
     r"""HourGlassBlock from :cite:`ULVL2016`.
 
-    This block comprises a
-    :func:`downsample`  to half the size
-    using :class:`~torch.nn.AvgPool2d` followed by a processing with ``intermediate``
-    and an :func:`upsample` to twice the
-    size using :class:`~torch.nn.Upsample`.
+    This block embeds an ``intermediate`` module between a :func:`downsample` and
+    :func:`upsample` operation.
 
     Args:
         intermediate: Module in between the down- and upsampling.

--- a/pystiche_papers/ulyanov_et_al_2016/_nst.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_nst.py
@@ -167,7 +167,10 @@ def stylization(
     """
     device = input_image.device
     if isinstance(transformer, str):
-        transformer = _transformer(impl_params=impl_params, instance_norm=instance_norm)
+        style = transformer
+        transformer = _transformer(
+            style=style, impl_params=impl_params, instance_norm=instance_norm,
+        )
         if instance_norm or not impl_params:
             # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/test.lua#L32
             transformer = transformer.eval()

--- a/pystiche_papers/ulyanov_et_al_2016/_nst.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_nst.py
@@ -167,10 +167,7 @@ def stylization(
     """
     device = input_image.device
     if isinstance(transformer, str):
-        style = transformer
-        transformer = _transformer(
-            style=style, impl_params=impl_params, instance_norm=instance_norm,
-        )
+        transformer = _transformer(impl_params=impl_params, instance_norm=instance_norm)
         if instance_norm or not impl_params:
             # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/test.lua#L32
             transformer = transformer.eval()


### PR DESCRIPTION
Partially supersedes [#144](https://github.com/pmeier/pystiche_papers/pull/144).