### PR TITLE
explicitly set black version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,7 @@ on:
       - "requirements-dev.txt"
       - "setup.cfg"
       - "tox.ini"
+      - ".pre-commit-config.yaml"
 
   schedule:
     - cron: "0 4 * * *"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: isort
         args: [--settings=pyproject.toml]
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: "19.10b0"
     hooks:
       - id: black
         args: [--config=pyproject.toml]


### PR DESCRIPTION
The release of `black>=20` broke the CI pipeline due to changes to trailing commas. We'll use the old version for now until we have time to investigate this further.