### PR TITLE
Fix same size padding

### DIFF
--- a/pystiche_papers/johnson_alahi_li_2016/_modules.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_modules.py
@@ -1,7 +1,7 @@
 import csv
 from math import sqrt
 from os import path
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast
 
 import torch
 from torch import nn
@@ -66,6 +66,13 @@ def conv(
     padding: Optional[Union[Tuple[int, int], int]] = None,
     upsample: bool = False,
 ) -> Union[SameSizeConv2d, nn.Conv2d, SameSizeConvTranspose2d, nn.ConvTranspose2d]:
+    cls: Union[
+        Type[SameSizeConv2d],
+        Type[nn.Conv2d],
+        Type[SameSizeConvTranspose2d],
+        Type[nn.ConvTranspose2d],
+    ]
+    kwargs: Dict[str, Any]
     if padding is None:
         cls = SameSizeConvTranspose2d if upsample else SameSizeConv2d
         kwargs = {}

--- a/pystiche_papers/johnson_alahi_li_2016/_modules.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_modules.py
@@ -9,7 +9,7 @@ from torch import nn
 import pystiche
 from pystiche_papers.utils import load_state_dict_from_url
 
-from ..utils import ResidualBlock, same_size_output_padding, same_size_padding
+from ..utils import ResidualBlock, SameSizeConv2d, SameSizeConvTranspose2d
 
 __all__ = [
     "conv",
@@ -65,25 +65,14 @@ def conv(
     stride: Union[Tuple[int, int], int] = 1,
     padding: Optional[Union[Tuple[int, int], int]] = None,
     upsample: bool = False,
-) -> Union[nn.Conv2d, nn.ConvTranspose2d]:
+) -> Union[SameSizeConv2d, nn.Conv2d, SameSizeConvTranspose2d, nn.ConvTranspose2d]:
     if padding is None:
-        padding = cast(Union[Tuple[int, int], int], same_size_padding(kernel_size))
-    if not upsample:
-        return nn.Conv2d(
-            in_channels, out_channels, kernel_size, stride=stride, padding=padding,
-        )
+        cls = SameSizeConvTranspose2d if upsample else SameSizeConv2d
+        kwargs = {}
     else:
-        output_padding = cast(
-            Union[Tuple[int, int], int], same_size_output_padding(stride)
-        )
-        return nn.ConvTranspose2d(
-            in_channels,
-            out_channels,
-            kernel_size,
-            stride=stride,
-            padding=padding,
-            output_padding=output_padding,
-        )
+        cls = nn.ConvTranspose2d if upsample else nn.Conv2d
+        kwargs = dict(padding=padding)
+    return cls(in_channels, out_channels, kernel_size, stride=stride, **kwargs)
 
 
 def norm(
@@ -268,11 +257,10 @@ def decoder(
             upsample=True,
             instance_norm=instance_norm,
         ),
-        nn.Conv2d(
+        SameSizeConv2d(
             in_channels=maybe_fix_num_channels(32, instance_norm),
             out_channels=3,
             kernel_size=9,
-            padding=same_size_padding(kernel_size=9),
         ),
         get_value_range_delimiter(),
     )

--- a/pystiche_papers/johnson_alahi_li_2016/_modules.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_modules.py
@@ -65,13 +65,8 @@ def conv(
     stride: Union[Tuple[int, int], int] = 1,
     padding: Optional[Union[Tuple[int, int], int]] = None,
     upsample: bool = False,
-) -> Union[SameSizeConv2d, nn.Conv2d, SameSizeConvTranspose2d, nn.ConvTranspose2d]:
-    cls: Union[
-        Type[SameSizeConv2d],
-        Type[nn.Conv2d],
-        Type[SameSizeConvTranspose2d],
-        Type[nn.ConvTranspose2d],
-    ]
+) -> Union[nn.Conv2d, nn.ConvTranspose2d]:
+    cls: Union[Type[nn.Conv2d], Type[nn.ConvTranspose2d]]
     kwargs: Dict[str, Any]
     if padding is None:
         cls = SameSizeConvTranspose2d if upsample else SameSizeConv2d

--- a/pystiche_papers/ulyanov_et_al_2016/_modules.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_modules.py
@@ -8,7 +8,7 @@ from torch import nn
 from pystiche import meta as meta_
 from pystiche import misc
 
-from ..utils import SequentialWithOutChannels, is_valid_padding, same_size_padding
+from ..utils import SameSizeConv2d, SequentialWithOutChannels
 
 
 def join_channelwise(*inputs: torch.Tensor, channel_dim: int = 1) -> torch.Tensor:
@@ -158,26 +158,20 @@ class ConvBlock(SequentialWithOutChannels):
         instance_norm: bool = True,
         inplace: bool = True,
     ) -> None:
-        padding = cast(
-            Union[Tuple[int, int, int, int], int], same_size_padding(kernel_size)
-        )
-
-        modules: List[Tuple[str, nn.Module]] = []
-
-        if is_valid_padding(padding):
-            modules.append(("pad", nn.ReflectionPad2d(padding)))
-
-        modules.append(
+        modules = (
             (
                 "conv",
-                nn.Conv2d(
-                    in_channels, out_channels, kernel_size, stride=stride, padding=0
+                SameSizeConv2d(
+                    in_channels,
+                    out_channels,
+                    kernel_size,
+                    stride=stride,
+                    padding_mode="reflect",
                 ),
-            )
+            ),
+            ("norm", norm(out_channels, instance_norm)),
+            ("act", activation(impl_params, instance_norm, inplace=inplace)),
         )
-        modules.append(("norm", norm(out_channels, instance_norm)))
-        modules.append(("act", activation(impl_params, instance_norm, inplace=inplace)))
-
         super().__init__(OrderedDict(modules), out_channel_name="conv")
 
 

--- a/pystiche_papers/utils/misc.py
+++ b/pystiche_papers/utils/misc.py
@@ -23,6 +23,7 @@ from pystiche.optim import OptimLogger
 
 __all__ = [
     "same_size_padding",
+    "full_padding",
     "same_size_output_padding",
     "is_valid_padding",
     "get_padding",

--- a/pystiche_papers/utils/misc.py
+++ b/pystiche_papers/utils/misc.py
@@ -4,11 +4,8 @@ import random
 import shutil
 import tempfile
 from collections import OrderedDict
-from collections.abc import Sequence
 from os import path
-from typing import Any, Callable, Dict, Iterator, Optional
-from typing import Sequence as SequenceType
-from typing import Tuple, TypeVar, Union, cast, overload
+from typing import Any, Dict, Iterator, Optional, Union, cast
 
 import numpy as np
 
@@ -18,15 +15,9 @@ from torch.hub import _get_torch_home
 from torch.utils.data.dataloader import DataLoader
 
 from pystiche.image import extract_batch_size, is_single_image, make_batched_image
-from pystiche.misc import verify_str_arg
 from pystiche.optim import OptimLogger
 
 __all__ = [
-    "same_size_padding",
-    "full_padding",
-    "same_size_output_padding",
-    "is_valid_padding",
-    "get_padding",
     "batch_up_image",
     "paper_replication",
     "make_reproducible",
@@ -35,97 +26,6 @@ __all__ = [
     "save_state_dict",
     "load_state_dict_from_url",
 ]
-
-In = TypeVar("In")
-Out = TypeVar("Out")
-
-
-@overload
-def elementwise(fn: Callable[[In], Out], inputs: In) -> Out:  # type: ignore[misc]
-    ...
-
-
-@overload
-def elementwise(fn: Callable[[In], Out], inputs: SequenceType[In]) -> Tuple[Out, ...]:
-    ...
-
-
-def elementwise(
-    fn: Callable[[In], Out], inputs: Union[In, SequenceType[In]]
-) -> Union[Out, Tuple[Out, ...]]:
-    if isinstance(inputs, Sequence):
-        return tuple(fn(input) for input in inputs)
-    return fn(inputs)
-
-
-@overload
-def same_size_padding(kernel_size: int) -> int:
-    ...
-
-
-@overload
-def same_size_padding(kernel_size: SequenceType[int]) -> Tuple[int, ...]:
-    ...
-
-
-def same_size_padding(
-    kernel_size: Union[int, SequenceType[int]]
-) -> Union[int, Tuple[int, ...]]:
-    return elementwise(lambda x: (x - 1) // 2, kernel_size)  # type: ignore[no-any-return]
-
-
-@overload
-def full_padding(kernel_size: int) -> int:
-    ...
-
-
-@overload
-def full_padding(kernel_size: SequenceType[int]) -> Tuple[int, ...]:
-    ...
-
-
-def full_padding(
-    kernel_size: Union[int, SequenceType[int]]
-) -> Union[int, Tuple[int, ...]]:
-    return elementwise(lambda x: x - 1, kernel_size)  # type: ignore[no-any-return]
-
-
-@overload
-def same_size_output_padding(stride: int) -> int:
-    ...
-
-
-@overload
-def same_size_output_padding(stride: SequenceType[int]) -> Tuple[int, ...]:
-    ...
-
-
-def same_size_output_padding(
-    stride: Union[int, SequenceType[int]]
-) -> Union[int, Tuple[int, ...]]:
-    return elementwise(lambda x: x - 1, stride)  # type: ignore[no-any-return]
-
-
-def is_valid_padding(padding: Union[int, SequenceType[int]]) -> bool:
-    def is_valid(x: int) -> bool:
-        return x > 0
-
-    if isinstance(padding, int):
-        return is_valid(padding)
-    else:
-        return all(elementwise(is_valid, padding))
-
-
-def get_padding(
-    padding: str, kernel_size: Union[Tuple[int, int], int]
-) -> Union[Tuple[int, int], int]:
-    padding = verify_str_arg(padding, valid_args=["same", "valid", "full"])
-    if padding == "same":
-        return cast(Tuple[int, int], same_size_padding(kernel_size))
-    elif padding == "full":
-        return cast(Tuple[int, int], full_padding(kernel_size))
-    else:  # padding == "valid"
-        return 0
 
 
 def batch_up_image(

--- a/pystiche_papers/utils/modules.py
+++ b/pystiche_papers/utils/modules.py
@@ -87,7 +87,7 @@ class _SameSizeConvNd(pystiche.Module):
         )
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        return self._conv(F.pad(input, self._pad, mode=self._mode))
+        return cast(torch.Tensor, self._conv(F.pad(input, self._pad, mode=self._mode)))
 
     def __getattr__(self, name: str) -> Any:
         if name == "_conv":

--- a/pystiche_papers/utils/modules.py
+++ b/pystiche_papers/utils/modules.py
@@ -9,6 +9,7 @@ __all__ = [
     "Identity",
     "ResidualBlock",
     "SequentialWithOutChannels",
+    "PaddedConv2D"
 ]
 
 
@@ -85,7 +86,7 @@ class PaddedConv2D(nn.Conv2d):
                 sum(
                     tuple(
                         (0, 1) if self.is_any_even(size) else (0, 0)
-                        for size in kernel_size
+                        for size in reversed(kernel_size)
                     ),
                     (),
                 )

--- a/pystiche_papers/utils/modules.py
+++ b/pystiche_papers/utils/modules.py
@@ -1,7 +1,9 @@
-from typing import Any, Dict, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import torch
 from torch import nn
+
+from ..utils import get_padding
 
 __all__ = [
     "Identity",
@@ -41,3 +43,51 @@ class SequentialWithOutChannels(nn.Sequential):
         self.out_channels = cast(Dict[str, nn.Module], self._modules)[
             out_channel_name
         ].out_channels
+
+
+class PaddedConv2D(nn.Conv2d):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: Union[Tuple[int, int], int],
+        padding: str = "valid",
+        **kwargs: Any,
+    ) -> None:
+        self.use_correction_padding = False
+        if self.is_any_even(kernel_size) and padding == "same":
+            self.use_correction_padding = True
+            self.correction_padding = self.get_padding_correction(kernel_size)
+
+        super().__init__(
+            in_channels,
+            out_channels,
+            kernel_size=kernel_size,
+            padding=get_padding(padding, kernel_size),
+            **kwargs,
+        )
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        if self.use_correction_padding:
+            input = nn.functional.pad(input, self.correction_padding)
+        return cast(torch.Tensor, self._conv_forward(input, self.weight))
+
+    def is_any_even(self, inputs: Union[Tuple[int, int], int]) -> bool:
+        if isinstance(inputs, tuple):
+            return any(input % 2 == 0 for input in inputs)
+        return inputs % 2 == 0
+
+    def get_padding_correction(
+        self, kernel_size: Union[Tuple[int, int], int]
+    ) -> List[int]:
+        if isinstance(kernel_size, tuple):
+            return list(
+                sum(
+                    tuple(
+                        (0, 1) if self.is_any_even(size) else (0, 0)
+                        for size in kernel_size
+                    ),
+                    (),
+                )
+            )
+        return [0, 1, 0, 1]

--- a/pystiche_papers/utils/modules.py
+++ b/pystiche_papers/utils/modules.py
@@ -5,12 +5,7 @@ from torch import nn
 
 from ..utils import get_padding
 
-__all__ = [
-    "Identity",
-    "ResidualBlock",
-    "SequentialWithOutChannels",
-    "PaddedConv2D"
-]
+__all__ = ["Identity", "ResidualBlock", "SequentialWithOutChannels", "PaddedConv2D"]
 
 
 class Identity(nn.Module):

--- a/tests/unit/johnson_alahi_li_2016/test_modules.py
+++ b/tests/unit/johnson_alahi_li_2016/test_modules.py
@@ -11,9 +11,14 @@ import pystiche_papers.johnson_alahi_li_2016 as paper
 from pystiche import misc
 from pystiche_papers import utils
 from pystiche_papers.johnson_alahi_li_2016._modules import select_url
-from pystiche_papers.utils import load_state_dict_from_url
+from pystiche_papers.utils import (
+    SameSizeConv2d,
+    SameSizeConvTranspose2d,
+    load_state_dict_from_url,
+)
 
 from tests.asserts import assert_downloads_correctly, assert_is_downloadable
+from tests.utils import generate_param_combinations
 
 
 @pytest.fixture(scope="module")
@@ -88,36 +93,37 @@ def test_get_conv(subtests):
     in_channels = out_channels = 3
     kernel_size = 3
     stride = 1
-    for padding, upsample in itertools.product((None, 1, (1, 1)), (True, False)):
-        conv = paper.conv(
-            in_channels,
-            out_channels,
-            kernel_size,
-            stride=stride,
-            padding=padding,
-            upsample=upsample,
-        )
+    for params in generate_param_combinations(
+        padding=(None, 1), upsample=(True, False)
+    ):
+        with subtests.test(**params):
+            conv = paper.conv(
+                in_channels, out_channels, kernel_size, stride=stride, **params
+            )
 
-        assert isinstance(conv, nn.ConvTranspose2d if upsample else nn.Conv2d)
+            if params["padding"] is None:
+                assert isinstance(
+                    conv,
+                    SameSizeConvTranspose2d if params["upsample"] else SameSizeConv2d,
+                )
+            else:
+                assert isinstance(
+                    conv, nn.ConvTranspose2d if params["upsample"] else nn.Conv2d
+                )
+                with subtests.test("padding"):
+                    assert conv.padding == misc.to_2d_arg(params["padding"])
 
-        with subtests.test("in_channels"):
-            assert conv.in_channels == in_channels
+            with subtests.test("in_channels"):
+                assert conv.in_channels == in_channels
 
-        with subtests.test("out_channels"):
-            assert conv.out_channels == out_channels
+            with subtests.test("out_channels"):
+                assert conv.out_channels == out_channels
 
-        with subtests.test("kernel_size"):
-            assert conv.kernel_size == misc.to_2d_arg(kernel_size)
+            with subtests.test("kernel_size"):
+                assert conv.kernel_size == misc.to_2d_arg(kernel_size)
 
-        with subtests.test("stride"):
-            assert conv.stride == misc.to_2d_arg(stride)
-
-        with subtests.test("padding"):
-            assert conv.padding == (1, 1)
-
-        if upsample:
-            with subtests.test("output_padding"):
-                assert conv.output_padding == misc.to_2d_arg(0)
+            with subtests.test("stride"):
+                assert conv.stride == misc.to_2d_arg(stride)
 
 
 def test_get_norm(subtests):
@@ -150,27 +156,38 @@ def test_conv_block(subtests):
     in_channels = out_channels = 3
     kernel_size = 3
     stride = 1
-    for relu, instance_norm in itertools.product((True, False), (True, False)):
-        with subtests.test(relu=relu):
-            conv_block = paper.conv_block(
-                in_channels,
-                out_channels,
-                kernel_size,
-                stride=stride,
-                relu=relu,
-                instance_norm=instance_norm,
-            )
+    for params in generate_param_combinations(
+        padding=(None, 1),
+        upsample=(True, False),
+        relu=(True, False),
+        inplace=(True, False),
+        instance_norm=(True, False),
+    ):
+        conv_block = paper.conv_block(
+            in_channels, out_channels, kernel_size, stride=stride, **params
+        )
+        assert isinstance(conv_block, nn.Sequential)
+        assert len(conv_block) == 3 if params["relu"] else 2
 
-            assert isinstance(conv_block, nn.Sequential)
-
-            assert len(conv_block) == 3 if relu else 2
-            assert isinstance(conv_block[0], nn.Conv2d)
+        with subtests.test("conv"):
             assert isinstance(
-                conv_block[1], nn.InstanceNorm2d if instance_norm else nn.BatchNorm2d
+                conv_block[0],
+                type(
+                    paper.conv(
+                        1, 1, 1, padding=params["padding"], upsample=params["upsample"]
+                    )
+                ),
             )
-            if relu:
+
+        with subtests.test("norm"):
+            assert isinstance(
+                conv_block[1], type(paper.norm(1, params["instance_norm"]))
+            )
+
+        if params["relu"]:
+            with subtests.test("relu"):
                 assert isinstance(conv_block[2], nn.ReLU)
-                assert conv_block[2].inplace
+                assert conv_block[2].inplace is params["inplace"]
 
 
 def test_residual_block(subtests, input_image):
@@ -224,7 +241,7 @@ def test_transformer_encoder(subtests):
                         (module[0].in_channels, module[0].out_channels)
                     )
             if i in range(4, 9):
-                with subtests.test("residualblocks"):
+                with subtests.test("residual_blocks"):
                     assert isinstance(module, utils.ResidualBlock)
                     in_out_channels.append(
                         (
@@ -256,7 +273,7 @@ def test_transformer_decoder(subtests):
                         )
                 if i == 2:
                     with subtests.test("output_conv"):
-                        assert isinstance(module, nn.Conv2d)
+                        assert isinstance(module, SameSizeConv2d)
                         in_out_channels.append(
                             (module.in_channels, module.out_channels)
                         )

--- a/tests/unit/johnson_alahi_li_2016/test_modules.py
+++ b/tests/unit/johnson_alahi_li_2016/test_modules.py
@@ -11,11 +11,7 @@ import pystiche_papers.johnson_alahi_li_2016 as paper
 from pystiche import misc
 from pystiche_papers import utils
 from pystiche_papers.johnson_alahi_li_2016._modules import select_url
-from pystiche_papers.utils import (
-    SameSizeConv2d,
-    SameSizeConvTranspose2d,
-    load_state_dict_from_url,
-)
+from pystiche_papers.utils import load_state_dict_from_url
 
 from tests.asserts import assert_downloads_correctly, assert_is_downloadable
 from tests.utils import generate_param_combinations
@@ -101,17 +97,9 @@ def test_get_conv(subtests):
                 in_channels, out_channels, kernel_size, stride=stride, **params
             )
 
-            if params["padding"] is None:
-                assert isinstance(
-                    conv,
-                    SameSizeConvTranspose2d if params["upsample"] else SameSizeConv2d,
-                )
-            else:
-                assert isinstance(
-                    conv, nn.ConvTranspose2d if params["upsample"] else nn.Conv2d
-                )
-                with subtests.test("padding"):
-                    assert conv.padding == misc.to_2d_arg(params["padding"])
+            assert isinstance(
+                conv, nn.ConvTranspose2d if params["upsample"] else nn.Conv2d
+            )
 
             with subtests.test("in_channels"):
                 assert conv.in_channels == in_channels
@@ -124,6 +112,10 @@ def test_get_conv(subtests):
 
             with subtests.test("stride"):
                 assert conv.stride == misc.to_2d_arg(stride)
+
+            if params["padding"] is not None:
+                with subtests.test("padding"):
+                    assert conv.padding == misc.to_2d_arg(params["padding"])
 
 
 def test_get_norm(subtests):
@@ -273,7 +265,7 @@ def test_transformer_decoder(subtests):
                         )
                 if i == 2:
                     with subtests.test("output_conv"):
-                        assert isinstance(module, SameSizeConv2d)
+                        assert isinstance(module, nn.Conv2d)
                         in_out_channels.append(
                             (module.in_channels, module.out_channels)
                         )

--- a/tests/unit/ulyanov_et_al_2016/test_modules.py
+++ b/tests/unit/ulyanov_et_al_2016/test_modules.py
@@ -9,7 +9,6 @@ from torch import nn
 
 import pystiche_papers.ulyanov_et_al_2016 as paper
 from pystiche import image, misc
-from pystiche_papers import utils
 
 
 def test_join_channelwise(subtests, image_small_0, image_small_1):
@@ -136,7 +135,7 @@ def test_ConvBlock(subtests):
 
     with subtests.test("conv"):
         conv = conv_block[0]
-        assert isinstance(conv, utils.SameSizeConv2d)
+        assert isinstance(conv, nn.Conv2d)
         assert conv.in_channels == in_channels
         assert conv.out_channels == out_channels
         assert conv.kernel_size == misc.to_2d_arg(kernel_size)

--- a/tests/unit/utils/test_misc.py
+++ b/tests/unit/utils/test_misc.py
@@ -17,45 +17,6 @@ from tests import assets
 from tests import utils as utils_
 
 
-def test_same_size_padding():
-    assert utils.same_size_padding(kernel_size=1) == 0
-    assert utils.same_size_padding(kernel_size=3) == 1
-    assert utils.same_size_padding(kernel_size=(1, 3)) == (0, 1)
-
-
-def test_full_padding():
-    assert utils.full_padding(kernel_size=1) == 0
-    assert utils.full_padding(kernel_size=3) == 2
-    assert utils.full_padding(kernel_size=(1, 3)) == (0, 2)
-
-
-def test_same_size_output_padding():
-    assert utils.same_size_output_padding(stride=1) == 0
-    assert utils.same_size_output_padding(stride=3) == 2
-    assert utils.same_size_output_padding(stride=(1, 3)) == (0, 2)
-
-
-def test_is_valid_padding():
-    assert utils.is_valid_padding(1)
-    assert not utils.is_valid_padding(0)
-    assert not utils.is_valid_padding(-1)
-
-    assert utils.is_valid_padding((1, 2))
-    assert not utils.is_valid_padding((1, 0, -1))
-
-
-def test_get_padding(subtests):
-    kernel_size = 3
-    for str_padding, desired in (
-        ("same", utils.same_size_padding(kernel_size)),
-        ("full", utils.full_padding(kernel_size)),
-        ("valid", 0),
-    ):
-        with subtests.test(str_padding):
-            actual = utils.get_padding(str_padding, kernel_size)
-            assert actual == desired
-
-
 def test_paper_replication(subtests, caplog):
     optim_logger = OptimLogger()
     starting_offset = optim_logger._environ_level_offset

--- a/tests/unit/utils/test_misc.py
+++ b/tests/unit/utils/test_misc.py
@@ -21,28 +21,18 @@ def test_same_size_padding():
     assert utils.same_size_padding(kernel_size=1) == 0
     assert utils.same_size_padding(kernel_size=3) == 1
     assert utils.same_size_padding(kernel_size=(1, 3)) == (0, 1)
-    assert utils.same_size_padding(kernel_size=2) == (0, 1)
-    assert utils.same_size_padding(kernel_size=(2, 4)) == (0, 1, 1, 2)
 
 
-def test_same_size_padding_image_size(subtests, input_image):
-    in_channels = out_channels = 3
-    for kernel_size in ((1,1), (2,2), (3,3), (4,4)):
-        with subtests.test(kernel_size=kernel_size):
-            conv = nn.Conv2d(
-                in_channels,
-                out_channels,
-                kernel_size=kernel_size,
-                padding=utils.same_size_padding(kernel_size),
-            )
-            output_image = conv(input_image)
-            assert input_image.size() == output_image.size()
+def test_full_padding():
+    assert utils.full_padding(kernel_size=1) == 0
+    assert utils.full_padding(kernel_size=3) == 2
+    assert utils.full_padding(kernel_size=(1, 3)) == (0, 2)
 
 
 def test_same_size_output_padding():
     assert utils.same_size_output_padding(stride=1) == 0
-    assert utils.same_size_output_padding(stride=2) == 1
-    assert utils.same_size_output_padding(stride=(1, 2)) == (0, 1)
+    assert utils.same_size_output_padding(stride=3) == 2
+    assert utils.same_size_output_padding(stride=(1, 3)) == (0, 2)
 
 
 def test_is_valid_padding():
@@ -52,6 +42,18 @@ def test_is_valid_padding():
 
     assert utils.is_valid_padding((1, 2))
     assert not utils.is_valid_padding((1, 0, -1))
+
+
+def test_get_padding(subtests):
+    kernel_size = 3
+    for str_padding, desired in (
+        ("same", utils.same_size_padding(kernel_size)),
+        ("full", utils.full_padding(kernel_size)),
+        ("valid", 0),
+    ):
+        with subtests.test(str_padding):
+            actual = utils.get_padding(str_padding, kernel_size)
+            assert actual == desired
 
 
 def test_paper_replication(subtests, caplog):

--- a/tests/unit/utils/test_misc.py
+++ b/tests/unit/utils/test_misc.py
@@ -21,6 +21,8 @@ def test_same_size_padding():
     assert utils.same_size_padding(kernel_size=1) == 0
     assert utils.same_size_padding(kernel_size=3) == 1
     assert utils.same_size_padding(kernel_size=(1, 3)) == (0, 1)
+    assert utils.same_size_padding(kernel_size=2) == (0, 1)
+    assert utils.same_size_padding(kernel_size=(2, 4)) == (0, 1, 1, 2)
 
 
 def test_same_size_output_padding():

--- a/tests/unit/utils/test_misc.py
+++ b/tests/unit/utils/test_misc.py
@@ -25,6 +25,20 @@ def test_same_size_padding():
     assert utils.same_size_padding(kernel_size=(2, 4)) == (0, 1, 1, 2)
 
 
+def test_same_size_padding_image_size(subtests, input_image):
+    in_channels = out_channels = 3
+    for kernel_size in ((1,1), (2,2), (3,3), (4,4)):
+        with subtests.test(kernel_size=kernel_size):
+            conv = nn.Conv2d(
+                in_channels,
+                out_channels,
+                kernel_size=kernel_size,
+                padding=utils.same_size_padding(kernel_size),
+            )
+            output_image = conv(input_image)
+            assert input_image.size() == output_image.size()
+
+
 def test_same_size_output_padding():
     assert utils.same_size_output_padding(stride=1) == 0
     assert utils.same_size_output_padding(stride=2) == 1

--- a/tests/unit/utils/test_modules.py
+++ b/tests/unit/utils/test_modules.py
@@ -1,11 +1,12 @@
 from collections import OrderedDict
-
+import itertools
 import pytest
 
 import pytorch_testing_utils as ptu
 import torch
 from torch import nn
 
+from pystiche.misc import to_2d_arg
 from pystiche_papers import utils
 
 
@@ -65,3 +66,25 @@ def test_SequentialWithOutChannels_forward_behaviour(input_image):
     for module in sequential_modules:
         desired = module(desired)
     ptu.assert_allclose(actual, desired)
+
+
+def test_PaddedConv2D(subtests, input_image):
+    in_channels = out_channels = 3
+
+    for kernel_size, padding in itertools.product((3, 4, (3, 3), (3, 4), (4, 3), (4, 4)), ("same", "valid", "full")):
+        with subtests.test(kernel_size=kernel_size, padding=padding):
+            padded_conv = utils.PaddedConv2D(in_channels, out_channels, kernel_size, padding=padding)
+
+            with subtests.test("padding"):
+                assert padded_conv.padding == to_2d_arg(utils.get_padding(padding, kernel_size))
+
+            with subtests.test("forward_size"):
+                output_image = padded_conv(input_image)
+                if padding == "same":
+                    desired_image_size = input_image.size()
+                else:
+                    conv = nn.Conv2d(in_channels, out_channels, kernel_size, padding=utils.get_padding(padding, kernel_size))
+                    desired_image_size = conv(input_image).size()
+
+                assert desired_image_size == output_image.size()
+

--- a/tests/unit/utils/test_modules.py
+++ b/tests/unit/utils/test_modules.py
@@ -1,5 +1,6 @@
-from collections import OrderedDict
 import itertools
+from collections import OrderedDict
+
 import pytest
 
 import pytorch_testing_utils as ptu
@@ -71,20 +72,30 @@ def test_SequentialWithOutChannels_forward_behaviour(input_image):
 def test_PaddedConv2D(subtests, input_image):
     in_channels = out_channels = 3
 
-    for kernel_size, padding in itertools.product((3, 4, (3, 3), (3, 4), (4, 3), (4, 4)), ("same", "valid", "full")):
+    for kernel_size, padding in itertools.product(
+        (3, 4, (3, 3), (3, 4), (4, 3), (4, 4)), ("same", "valid", "full")
+    ):
         with subtests.test(kernel_size=kernel_size, padding=padding):
-            padded_conv = utils.PaddedConv2D(in_channels, out_channels, kernel_size, padding=padding)
+            padded_conv = utils.PaddedConv2D(
+                in_channels, out_channels, kernel_size, padding=padding
+            )
 
             with subtests.test("padding"):
-                assert padded_conv.padding == to_2d_arg(utils.get_padding(padding, kernel_size))
+                assert padded_conv.padding == to_2d_arg(
+                    utils.get_padding(padding, kernel_size)
+                )
 
             with subtests.test("forward_size"):
                 output_image = padded_conv(input_image)
                 if padding == "same":
                     desired_image_size = input_image.size()
                 else:
-                    conv = nn.Conv2d(in_channels, out_channels, kernel_size, padding=utils.get_padding(padding, kernel_size))
+                    conv = nn.Conv2d(
+                        in_channels,
+                        out_channels,
+                        kernel_size,
+                        padding=utils.get_padding(padding, kernel_size),
+                    )
                     desired_image_size = conv(input_image).size()
 
                 assert desired_image_size == output_image.size()
-

--- a/tests/unit/utils/test_modules.py
+++ b/tests/unit/utils/test_modules.py
@@ -136,6 +136,26 @@ def test_SameSizeConv2d_repr_smoke():
     assert isinstance(repr(same_size_conv), str)
 
 
+def test_SameSizeConv2d_state_dict():
+    kwargs = dict(in_channels=1, out_channels=2, kernel_size=3, bias=True)
+    conv = nn.Conv2d(**kwargs)
+    same_size_conv = utils.SameSizeConv2d(**kwargs)
+
+    state_dict = conv.state_dict()
+    same_size_conv.load_state_dict(state_dict)
+    ptu.assert_allclose(same_size_conv.state_dict(), state_dict)
+
+
 def test_SameSizeConvTranspose2d_output_padding():
     with pytest.raises(RuntimeError):
         utils.SameSizeConvTranspose2d(1, 1, 3, output_padding=1)
+
+
+def test_SameSizeConvTranspose2d_state_dict():
+    kwargs = dict(in_channels=1, out_channels=2, kernel_size=3, bias=True)
+    conv = nn.ConvTranspose2d(**kwargs)
+    same_size_conv = utils.SameSizeConvTranspose2d(**kwargs)
+
+    state_dict = conv.state_dict()
+    same_size_conv.load_state_dict(state_dict)
+    ptu.assert_allclose(same_size_conv.state_dict(), state_dict)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 import contextlib
+import itertools
 import os
 import shutil
 import tempfile
@@ -18,6 +19,7 @@ __all__ = [
     "is_callable",
     "create_guides",
     "call_args_list_to_dict",
+    "generate_param_combinations",
 ]
 
 
@@ -123,3 +125,10 @@ def call_args_list_to_dict(call_args_list, map, args_idx=None, kwargs_key=None):
         raise pytest.UsageError
 
     return call_args_dict
+
+
+def generate_param_combinations(**kwargs):
+    names = tuple(kwargs.keys())
+    iterables = tuple(kwargs.values())
+    for params in itertools.product(*iterables):
+        yield dict(zip(names, params))


### PR DESCRIPTION
As mentioned in [#174](https://github.com/pmeier/pystiche_papers/pull/174#discussion_r481221830).

If the `kernel_size` is even, the `same_size_padding` requires an additional right column at the height and/or an additional bottom column so that the `input_size `is not changed.