### PR TITLE
Fix  codecov action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
         run: tox -e tests-unit -- tests/unit --skip-large-download
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v1.0.7
+        uses: codecov/codecov-action@v1.0.13
         with:
           env_vars: OS,PYTHON
 


### PR DESCRIPTION
As of recently codecov complains that it can't detect a CI provider. 