### PR TITLE
Hyper-parameters: proof of concept

### DIFF
--- a/docs/source/api/pystiche_papers.gatys_ecker_bethge_2016.rst
+++ b/docs/source/api/pystiche_papers.gatys_ecker_bethge_2016.rst
@@ -14,6 +14,7 @@ are affected:
 .. automodule:: pystiche_papers.gatys_ecker_bethge_2016
 
 .. autofunction:: content_loss
+.. autofunction:: hyper_parameters
 .. autofunction:: images
 .. autofunction:: multi_layer_encoder
 .. autofunction:: nst

--- a/pystiche_papers/gatys_ecker_bethge_2016/_loss.py
+++ b/pystiche_papers/gatys_ecker_bethge_2016/_loss.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional, Sequence, Union
+from typing import Callable, Optional, Sequence, Union
 
 import torch
 from torch.nn.functional import mse_loss
@@ -57,13 +57,11 @@ def content_loss(
         impl_params: If ``True``, uses the parameters used in the reference
             implementation of the original authors rather than what is described in
             the paper. For details see below.
-        multi_layer_encoder: Pretrained :class:`~pystiche.enc.MultiLayerEncoder`. If
-            omitted, the default
+        multi_layer_encoder: If omitted,
             :func:`~pystiche_papers.gatys_ecker_bethge_2016.multi_layer_encoder` is
             used.
-        layer: Layer from which the encodings of the ``multi_layer_encoder`` should be
-            taken. Defaults to ``"relu4_2"``.
-        score_weight: Score weight of the operator. Defaults to ``1e0``.
+        hyper_parameters: If omitted,
+            :func:`~pystiche_papers.gatys_ecker_bethge_2016.hyper_parameters` is used.
 
     If ``impl_params is True``,
 
@@ -116,7 +114,6 @@ def style_loss(
     impl_params: bool = True,
     multi_layer_encoder: Optional[enc.MultiLayerEncoder] = None,
     hyper_parameters: Optional[HyperParameters] = None,
-    **gram_loss_kwargs: Any,
 ) -> StyleLoss:
     r"""Style_loss from :cite:`GEB2016`.
 
@@ -124,20 +121,11 @@ def style_loss(
         impl_params: If ``True``, uses the parameters used in the reference
             implementation of the original authors rather than what is described in
             the paper. For details see below.
-        multi_layer_encoder: Pretrained :class:`~pystiche.enc.MultiLayerEncoder`. If
-            omitted, the default
+        multi_layer_encoder: If omitted,
             :func:`~pystiche_papers.gatys_ecker_bethge_2016.multi_layer_encoder` is
             used.
-        layers: Layers from which the encodings of the ``multi_layer_encoder`` should be
-            taken. If omitted, the defaults is used. Defaults to
-            ``("relu1_1", "relu2_1", "relu3_1", "relu4_1", "relu5_1")``.
-        layer_weights: Layer weights of the operator. If omitted, the layer weights are
-            calculated with ``1.0 / num_channels ** 2.0`` as described in the paper.
-            Here the ``num_channels`` are the number of channels in the respective
-            layer.
-        score_weight: Score weight of the operator. Defaults to ``1e3``.
-        **gram_loss_kwargs: Optional parameters for the
-            :class:`~pystiche.ops.GramOperator`.
+        hyper_parameters: If omitted,
+            :func:`~pystiche_papers.gatys_ecker_bethge_2016.hyper_parameters` is used.
 
     If ``impl_params is True`` , no additional score correction factor of ``1.0 / 4.0``
     is used.
@@ -150,7 +138,7 @@ def style_loss(
         hyper_parameters = _hyper_parameters()
 
     def get_encoding_op(encoder: enc.Encoder, layer_weight: float) -> ops.GramOperator:
-        return ops.GramOperator(encoder, score_weight=layer_weight, **gram_loss_kwargs)
+        return ops.GramOperator(encoder, score_weight=layer_weight)
 
     return StyleLoss(
         multi_layer_encoder,
@@ -173,13 +161,11 @@ def perceptual_loss(
         impl_params: If ``True``, uses the parameters used in the reference
             implementation of the original authors rather than what is described in
             the paper.
-        multi_layer_encoder: Pretrained :class:`~pystiche.enc.MultiLayerEncoder`. If
-            omitted, the default
+        multi_layer_encoder: If omitted,
             :func:`~pystiche_papers.gatys_ecker_bethge_2016.multi_layer_encoder` is
             used.
-        content_loss_kwargs: Optional parameters for the :func:`content_loss`.
-        style_loss_kwargs: Optional parameters for the :func:`style_loss`.
-
+        hyper_parameters: If omitted,
+            :func:`~pystiche_papers.gatys_ecker_bethge_2016.hyper_parameters` is used.
     """
     if multi_layer_encoder is None:
         multi_layer_encoder = _multi_layer_encoder(impl_params=impl_params)

--- a/pystiche_papers/gatys_ecker_bethge_2016/_loss.py
+++ b/pystiche_papers/gatys_ecker_bethge_2016/_loss.py
@@ -75,9 +75,7 @@ def content_loss(
         multi_layer_encoder = _multi_layer_encoder(impl_params=impl_params)
 
     if hyper_parameters is None:
-        hyper_parameters = _hyper_parameters(
-            impl_params=impl_params, multi_layer_encoder=multi_layer_encoder
-        )
+        hyper_parameters = _hyper_parameters()
 
     return FeatureReconstructionOperator(
         multi_layer_encoder.extract_encoder(hyper_parameters.content_loss.layer),
@@ -149,9 +147,7 @@ def style_loss(
         multi_layer_encoder = _multi_layer_encoder(impl_params=impl_params)
 
     if hyper_parameters is None:
-        hyper_parameters = _hyper_parameters(
-            impl_params=impl_params, multi_layer_encoder=multi_layer_encoder
-        )
+        hyper_parameters = _hyper_parameters()
 
     def get_encoding_op(encoder: enc.Encoder, layer_weight: float) -> ops.GramOperator:
         return ops.GramOperator(encoder, score_weight=layer_weight, **gram_loss_kwargs)
@@ -189,9 +185,7 @@ def perceptual_loss(
         multi_layer_encoder = _multi_layer_encoder(impl_params=impl_params)
 
     if hyper_parameters is None:
-        hyper_parameters = _hyper_parameters(
-            impl_params=impl_params, multi_layer_encoder=multi_layer_encoder
-        )
+        hyper_parameters = _hyper_parameters()
 
     return loss.PerceptualLoss(
         content_loss(

--- a/pystiche_papers/gatys_ecker_bethge_2016/_nst.py
+++ b/pystiche_papers/gatys_ecker_bethge_2016/_nst.py
@@ -52,7 +52,7 @@ def nst(
     a random initialized image.
     """
     if hyper_parameters is None:
-        hyper_parameters = _hyper_parameters(impl_params=impl_params)
+        hyper_parameters = _hyper_parameters()
 
     device = content_image.device
 

--- a/pystiche_papers/gatys_ecker_bethge_2016/_nst.py
+++ b/pystiche_papers/gatys_ecker_bethge_2016/_nst.py
@@ -3,9 +3,11 @@ from typing import Callable, Optional, Union
 import torch
 
 import pystiche
-from pystiche import loss, misc, optim
+from pystiche import misc, optim
+from pystiche_papers.utils import HyperParameters
 
 from ._loss import perceptual_loss
+from ._utils import hyper_parameters as _hyper_parameters
 from ._utils import optimizer
 from ._utils import postprocessor as _postprocessor
 from ._utils import preprocessor as _preprocessor
@@ -18,9 +20,8 @@ __all__ = [
 def nst(
     content_image: torch.Tensor,
     style_image: torch.Tensor,
-    num_steps: int = 500,
     impl_params: bool = True,
-    criterion: Optional[loss.PerceptualLoss] = None,
+    hyper_parameters: Optional[HyperParameters] = None,
     quiet: bool = False,
     logger: Optional[optim.OptimLogger] = None,
     log_fn: Optional[
@@ -50,10 +51,14 @@ def nst(
     If ``impl_params is True`` the content_image is set as the starting point instead of
     a random initialized image.
     """
-    if criterion is None:
-        criterion = perceptual_loss(impl_params=impl_params)
+    if hyper_parameters is None:
+        hyper_parameters = _hyper_parameters(impl_params=impl_params)
 
     device = content_image.device
+
+    criterion = perceptual_loss(
+        impl_params=impl_params, hyper_parameters=hyper_parameters
+    )
     criterion = criterion.to(device)
 
     # https://github.com/pmeier/PytorchNeuralStyleTransfer/blob/master/NeuralStyleTransfer.ipynb
@@ -73,7 +78,7 @@ def nst(
         input_image,
         criterion,
         get_optimizer=optimizer,
-        num_steps=num_steps,
+        num_steps=hyper_parameters.nst.num_steps,
         preprocessor=preprocessor,
         postprocessor=postprocessor,
         quiet=quiet,

--- a/pystiche_papers/gatys_ecker_bethge_2016/_nst.py
+++ b/pystiche_papers/gatys_ecker_bethge_2016/_nst.py
@@ -33,12 +33,11 @@ def nst(
     Args:
         content_image: Content image for the NST.
         style_image: Style image for the NST.
-        num_steps: Number of steps for each level. Defaults to ``500``.
         impl_params: If ``True``, uses the parameters used in the reference
             implementation of the original authors rather than what is described in
             the paper. For details see below.
-        criterion: Optimization criterion. If omitted, the default
-            :func:`~pystiche_papers.gatys_ecker_bethge_2016.perceptual_loss` is used.
+        hyper_parameters: If omitted,
+            :func:`~pystiche_papers.gatys_ecker_bethge_2016.hyper_parameters` is used.
         quiet: If ``True``, not information is logged during the optimization. Defaults
             to ``False``.
         logger: Optional custom logger. If ``None``,

--- a/pystiche_papers/gatys_ecker_bethge_2016/_utils.py
+++ b/pystiche_papers/gatys_ecker_bethge_2016/_utils.py
@@ -92,6 +92,7 @@ def compute_layer_weights(
 
 
 def hyper_parameters() -> HyperParameters:
+    r"""Hyper parameters from :cite:`GEB2016`."""
     style_loss_layers = ("relu1_1", "relu2_1", "relu3_1", "relu4_1", "relu5_1")
 
     return HyperParameters(

--- a/pystiche_papers/gatys_ecker_bethge_2016/_utils.py
+++ b/pystiche_papers/gatys_ecker_bethge_2016/_utils.py
@@ -1,14 +1,18 @@
+from typing import Optional, Sequence, Tuple, cast
+
 import torch
 from torch import nn, optim
 
 from pystiche import enc, meta
 from pystiche.image import transforms
+from pystiche_papers.utils import HyperParameters
 
 __all__ = [
     "preprocessor",
     "postprocessor",
     "optimizer",
     "multi_layer_encoder",
+    "hyper_parameters",
 ]
 
 
@@ -28,18 +32,18 @@ def multi_layer_encoder(impl_params: bool = True,) -> enc.MultiLayerEncoder:
             the ``multi_layer_encoder`` are exchanged for :class:`~torch.nn.AvgPool2d`.
 
     """
-    multi_layer_encoder = enc.vgg19_multi_layer_encoder(
+    multi_layer_encoder_ = enc.vgg19_multi_layer_encoder(
         weights="caffe", internal_preprocessing=False, allow_inplace=True
     )
     if impl_params:
-        return multi_layer_encoder
+        return multi_layer_encoder_
 
-    for name, module in multi_layer_encoder.named_children():
+    for name, module in multi_layer_encoder_.named_children():
         if isinstance(module, nn.MaxPool2d):
-            multi_layer_encoder._modules[name] = nn.AvgPool2d(
+            multi_layer_encoder_._modules[name] = nn.AvgPool2d(
                 **meta.pool_module_meta(module)
             )
-    return multi_layer_encoder
+    return multi_layer_encoder_
 
 
 def optimizer(input_image: torch.Tensor) -> optim.LBFGS:
@@ -50,3 +54,44 @@ def optimizer(input_image: torch.Tensor) -> optim.LBFGS:
 
     """
     return optim.LBFGS([input_image.requires_grad_(True)], lr=1.0, max_iter=1)
+
+
+def compute_layer_weights(
+    multi_layer_encoder: enc.MultiLayerEncoder, layers: Sequence[str],
+) -> Tuple[float, ...]:
+    nums_channels = []
+    for layer in layers:
+        if layer not in multi_layer_encoder:
+            raise RuntimeError
+
+        layer = layer.replace("relu", "conv")
+        if not layer.startswith("conv"):
+            raise RuntimeError
+
+        module = cast(nn.Conv2d, multi_layer_encoder._modules[layer])
+        nums_channels.append(module.out_channels)
+
+    return tuple(1.0 / num_channels ** 2.0 for num_channels in nums_channels)
+
+
+multi_layer_encoder_ = multi_layer_encoder
+
+
+def hyper_parameters(
+    impl_params: bool = True,
+    multi_layer_encoder: Optional[enc.MultiLayerEncoder] = None,
+) -> HyperParameters:
+    if multi_layer_encoder is None:
+        multi_layer_encoder = multi_layer_encoder_(impl_params=impl_params)
+
+    style_loss_layers = ("relu1_1", "relu2_1", "relu3_1", "relu4_1", "relu5_1")
+
+    return HyperParameters(
+        content_loss=HyperParameters(layer="relu4_2", score_weight=1e0),
+        style_loss=HyperParameters(
+            layers=style_loss_layers,
+            layer_weights=compute_layer_weights(multi_layer_encoder, style_loss_layers),
+            score_weight=1e3,
+        ),
+        nst=HyperParameters(num_steps=500),
+    )

--- a/pystiche_papers/utils/__init__.py
+++ b/pystiche_papers/utils/__init__.py
@@ -1,4 +1,5 @@
 from .cuda import *
+from .hyper_params import *
 from .misc import *
 from .modules import *
 from .transforms import *

--- a/pystiche_papers/utils/hyper_params.py
+++ b/pystiche_papers/utils/hyper_params.py
@@ -19,14 +19,14 @@ class HyperParameters(pystiche.ComplexObject):
             if name in dct:
                 return dct[name]
         else:
-            raise AttributeError
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{name}'"
+            )
 
     def __setattr__(self, name: str, value: Any) -> None:
         if name in ("__params__", "__sub_params__"):
             super().__setattr__(name, value)
             return
-        elif not all(dct in self.__dict__ for dct in ("__params__", "__sub_params__")):
-            raise AttributeError
 
         new_dct, old_dct = (
             (self.__sub_params__, self.__params__)

--- a/pystiche_papers/utils/hyper_params.py
+++ b/pystiche_papers/utils/hyper_params.py
@@ -1,0 +1,58 @@
+from collections import OrderedDict
+from typing import Any, Dict, Iterator, Tuple
+
+import pystiche
+
+__all__ = ["HyperParameters"]
+
+
+class HyperParameters(pystiche.ComplexObject):
+    def __init__(self, **kwargs: Any) -> None:
+        self.__params__: Dict[str, Any] = OrderedDict()
+        self.__sub_params__: Dict[str, Any] = OrderedDict()
+
+        for name, value in kwargs.items():
+            setattr(self, name, value)
+
+    def __getattr__(self, name: str) -> Any:
+        for dct in (self.__params__, self.__sub_params__):
+            if name in dct:
+                return dct[name]
+        else:
+            raise AttributeError
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name in ("__params__", "__sub_params__"):
+            super().__setattr__(name, value)
+            return
+        elif not all(dct in self.__dict__ for dct in ("__params__", "__sub_params__")):
+            raise AttributeError
+
+        new_dct, old_dct = (
+            (self.__sub_params__, self.__params__)
+            if isinstance(value, HyperParameters)
+            else (self.__params__, self.__sub_params__)
+        )
+
+        if name in old_dct:
+            del old_dct[name]
+        new_dct[name] = value
+
+    def __delattr__(self, name: str) -> None:
+        for dct in (self.__params__, self.__sub_params__):
+            if name in dct:
+                del dct[name]
+                break
+        else:
+            super().__delattr__(name)
+
+    def __contains__(self, name: str) -> bool:
+        return name in self.__params__ or name in self.__sub_params__
+
+    def _properties(self) -> Dict[str, Any]:
+        dct = super()._properties()
+        dct.update(self.__params__)
+        return dct
+
+    def _named_children(self) -> Iterator[Tuple[str, Any]]:
+        yield from self.__sub_params__.items()

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -47,11 +47,11 @@ def _load_multi_layer_encoder(loader, *args, **kwargs):
 
 
 def patch_multi_layer_encoder_loader(
-    target,
+    targets,
     loader,
     patch_load_weights=True,
     clear_cache=False,
-    setup=None,
+    setups=None,
     mocker=DEFAULT_MOCKER,
 ):
     if patch_load_weights:
@@ -65,13 +65,19 @@ def patch_multi_layer_encoder_loader(
         multi_layer_encoder.empty_storage()
         return multi_layer_encoder
 
-    patch = mocker.patch(target, new)
+    if not isinstance(targets, list):
+        targets = [targets]
 
-    if setup is not None:
-        args, kwargs = setup
-        new(*args, **kwargs)
+    patches = tuple(mocker.patch(target, new) for target in targets)
 
-    return patch
+    if setups is not None:
+        if not isinstance(setups, list):
+            setups = [setups]
+        for setup in setups:
+            args, kwargs = setup
+            new(*args, **kwargs)
+
+    return patches
 
 
 def _make_image_mock(image=None, mocker=DEFAULT_MOCKER):

--- a/tests/replication/test_gatys_ecker_bethge_2016.py
+++ b/tests/replication/test_gatys_ecker_bethge_2016.py
@@ -9,6 +9,7 @@ import torch
 
 import pystiche_papers.gatys_ecker_bethge_2016 as paper
 from pystiche import misc, optim
+from pystiche_papers.utils import HyperParameters
 
 from . import utils
 from .asserts import assert_dir_exists
@@ -100,28 +101,21 @@ def test_figure_2_smoke(subtests, images, nst, main, args):
     with subtests.test("content_image"):
         for call_args in nst.call_args_list:
             args, _ = call_args
-            content_image, _, _ = args
+            content_image, _ = args
             ptu.assert_allclose(content_image, images["neckarfront"].read())
 
     with subtests.test("style_image"):
         # TODO: make this more precise and also check score weight
         for call_args in nst.call_args_list:
             args, _ = call_args
-            _, style_image, _ = args
+            _, style_image = args
             assert isinstance(style_image, torch.Tensor)
 
-    with subtests.test("num_steps"):
-        for call_args in nst.call_args_list:
-            args, _ = call_args
-            _, _, num_steps = args
-            assert num_steps == 500
-
-    with subtests.test("perceptual_loss"):
-        criterion_type = type(paper.perceptual_loss())
+    with subtests.test("hyper_parameters"):
         for call_args in nst.call_args_list:
             _, kwargs = call_args
-            criterion = kwargs["criterion"]
-            assert isinstance(criterion, criterion_type)
+            hyper_parameters = kwargs["hyper_parameters"]
+            assert isinstance(hyper_parameters, HyperParameters)
 
 
 def test_figure_3_smoke(subtests, images, nst, main, args):
@@ -132,24 +126,17 @@ def test_figure_3_smoke(subtests, images, nst, main, args):
     with subtests.test("content_image"):
         for call_args in nst.call_args_list:
             args, _ = call_args
-            content_image, _, _ = args
+            content_image, _ = args
             ptu.assert_allclose(content_image, images["neckarfront"].read())
 
     with subtests.test("style_image"):
         for call_args in nst.call_args_list:
             args, _ = call_args
-            _, style_image, _ = args
+            _, style_image = args
             ptu.assert_allclose(style_image, images["composition_vii"].read())
 
-    with subtests.test("num_steps"):
-        for call_args in nst.call_args_list:
-            args, _ = call_args
-            _, _, num_steps = args
-            assert num_steps == 500
-
-    with subtests.test("perceptual_loss"):
-        criterion_type = type(paper.perceptual_loss())
+    with subtests.test("hyper_parameters"):
         for call_args in nst.call_args_list:
             _, kwargs = call_args
-            criterion = kwargs["criterion"]
-            assert isinstance(criterion, criterion_type)
+            hyper_parameters = kwargs["hyper_parameters"]
+            assert isinstance(hyper_parameters, HyperParameters)

--- a/tests/replication/test_gatys_ecker_bethge_2016.py
+++ b/tests/replication/test_gatys_ecker_bethge_2016.py
@@ -30,9 +30,9 @@ make_paper_mock_target = functools.partial(make_mock_target, PAPER)
 @pytest.fixture(scope="module", autouse=True)
 def multi_layer_encoder(module_mocker):
     return patch_multi_layer_encoder_loader(
-        target=make_paper_mock_target("_loss", "_multi_layer_encoder"),
+        targets=make_paper_mock_target("_loss", "_multi_layer_encoder"),
         loader=paper.multi_layer_encoder,
-        setup=((), {"impl_params": True}),
+        setups=((), {"impl_params": True}),
         mocker=module_mocker,
     )
 

--- a/tests/replication/test_gatys_et_al_2017.py
+++ b/tests/replication/test_gatys_et_al_2017.py
@@ -29,9 +29,9 @@ make_paper_mock_target = functools.partial(make_mock_target, PAPER)
 @pytest.fixture(scope="module", autouse=True)
 def multi_layer_encoder(module_mocker):
     return patch_multi_layer_encoder_loader(
-        target=make_paper_mock_target("_loss", "_multi_layer_encoder"),
+        targets=make_paper_mock_target("_loss", "_multi_layer_encoder"),
         loader=paper.multi_layer_encoder,
-        setup=((), {}),
+        setups=((), {}),
         mocker=module_mocker,
     )
 

--- a/tests/replication/test_johnson_alahi_li_2016.py
+++ b/tests/replication/test_johnson_alahi_li_2016.py
@@ -36,9 +36,9 @@ make_paper_mock_target = functools.partial(make_mock_target, PAPER)
 @pytest.fixture(scope="module", autouse=True)
 def multi_layer_encoder(module_mocker):
     return patch_multi_layer_encoder_loader(
-        target=make_paper_mock_target("_loss", "_multi_layer_encoder"),
+        targets=make_paper_mock_target("_loss", "_multi_layer_encoder"),
         loader=paper.multi_layer_encoder,
-        setup=((), {"impl_params": True}),
+        setups=((), {"impl_params": True}),
         mocker=module_mocker,
     )
 

--- a/tests/replication/test_li_wand_2016.py
+++ b/tests/replication/test_li_wand_2016.py
@@ -29,9 +29,9 @@ make_paper_mock_target = functools.partial(make_mock_target, PAPER)
 @pytest.fixture(scope="module", autouse=True)
 def multi_layer_encoder(module_mocker):
     return patch_multi_layer_encoder_loader(
-        target=make_paper_mock_target("_loss", "_multi_layer_encoder"),
+        targets=make_paper_mock_target("_loss", "_multi_layer_encoder"),
         loader=paper.multi_layer_encoder,
-        setup=((), {}),
+        setups=((), {}),
         mocker=module_mocker,
     )
 

--- a/tests/replication/test_ulyanov_et_al_2016.py
+++ b/tests/replication/test_ulyanov_et_al_2016.py
@@ -35,9 +35,9 @@ make_paper_mock_target = functools.partial(make_mock_target, PAPER)
 @pytest.fixture(scope="module", autouse=True)
 def multi_layer_encoder(module_mocker):
     return patch_multi_layer_encoder_loader(
-        target=make_paper_mock_target("_loss", "_multi_layer_encoder"),
+        targets=make_paper_mock_target("_loss", "_multi_layer_encoder"),
         loader=paper.multi_layer_encoder,
-        setup=((), {}),
+        setups=((), {}),
         mocker=module_mocker,
     )
 

--- a/tests/unit/gatys_ecker_bethge_2016/conftest.py
+++ b/tests/unit/gatys_ecker_bethge_2016/conftest.py
@@ -7,11 +7,19 @@ from tests import mocks
 
 @pytest.fixture(scope="package", autouse=True)
 def multi_layer_encoder(package_mocker):
+    setups = [((), {})]
+    setups.extend(
+        [((), dict(impl_params=impl_params)) for impl_params in (True, False)]
+    )
     return mocks.patch_multi_layer_encoder_loader(
-        target=mocks.make_mock_target(
-            "gatys_ecker_bethge_2016", "_loss", "_multi_layer_encoder"
-        ),
+        targets=[
+            mocks.make_mock_target("gatys_ecker_bethge_2016", *path)
+            for path in (
+                ("_loss", "_multi_layer_encoder"),
+                ("_utils", "multi_layer_encoder_"),
+            )
+        ],
         loader=paper.multi_layer_encoder,
-        setup=((), {"impl_params": True}),
+        setups=setups,
         mocker=package_mocker,
     )

--- a/tests/unit/gatys_ecker_bethge_2016/test_loss.py
+++ b/tests/unit/gatys_ecker_bethge_2016/test_loss.py
@@ -6,7 +6,6 @@ from torch.nn.functional import mse_loss
 import pystiche
 import pystiche_papers.gatys_ecker_bethge_2016 as paper
 from pystiche import loss, ops
-from pystiche_papers.gatys_ecker_bethge_2016._loss import get_layer_weights
 
 
 def test_FeatureReconstructionOperator(
@@ -34,11 +33,13 @@ def test_content_loss(subtests):
     content_loss = paper.content_loss()
     assert isinstance(content_loss, paper.FeatureReconstructionOperator)
 
+    hyper_parameters = paper.hyper_parameters().content_loss
+
     with subtests.test("layer"):
-        assert content_loss.encoder.layer == "relu4_2"
+        assert content_loss.encoder.layer == hyper_parameters.layer
 
     with subtests.test("score_weight"):
-        assert content_loss.score_weight == pytest.approx(1e0)
+        assert content_loss.score_weight == pytest.approx(hyper_parameters.score_weight)
 
 
 def test_StyleLoss(subtests, multi_layer_encoder_with_layer, target_image, input_image):
@@ -67,37 +68,11 @@ def test_StyleLoss(subtests, multi_layer_encoder_with_layer, target_image, input
             assert actual == ptu.approx(desired)
 
 
-def test_get_layer_weights():
-    layers, nums_channels = zip(
-        ("relu1_1", 64),
-        ("relu2_1", 128),
-        ("relu3_1", 256),
-        ("relu4_1", 512),
-        ("relu5_1", 512),
-    )
-
-    actual = get_layer_weights(layers)
-    desired = tuple(1.0 / num_channels ** 2.0 for num_channels in nums_channels)
-    assert actual == pytest.approx(desired)
-
-
-def test_get_layer_weights_wrong_layers(subtests):
-    with subtests.test("layer not in multi_layer_encoder"):
-        not_included_layers = ("not_included",)
-
-        with pytest.raises(RuntimeError):
-            get_layer_weights(not_included_layers)
-
-    with subtests.test("no conv or relu layer"):
-        no_conv_or_relu_layers = ("pool1",)
-
-        with pytest.raises(RuntimeError):
-            get_layer_weights(no_conv_or_relu_layers)
-
-
 def test_style_loss(subtests):
     style_loss = paper.style_loss()
     assert isinstance(style_loss, ops.MultiLayerEncodingOperator)
+
+    hyper_parameters = paper.hyper_parameters().style_loss
 
     with subtests.test("encoding_ops"):
         assert all(isinstance(op, ops.GramOperator) for op in style_loss.operators())
@@ -106,24 +81,13 @@ def test_style_loss(subtests):
         *[(op.encoder.layer, op.score_weight) for op in style_loss.operators()]
     )
     with subtests.test("layers"):
-        assert set(layers) == {"relu1_1", "relu2_1", "relu3_1", "relu4_1", "relu5_1"}
+        assert layers == hyper_parameters.layers
 
     with subtests.test("layer_weights"):
-        assert layer_weights == pytest.approx(get_layer_weights(layers))
+        assert layer_weights == pytest.approx(hyper_parameters.layer_weights)
 
     with subtests.test("score_weight"):
         assert style_loss.score_weight == pytest.approx(1e3)
-
-
-def test_style_loss_wrong_layers(mocker):
-    mock = mocker.patch("pystiche_papers.gatys_ecker_bethge_2016._loss.StyleLoss")
-
-    layers = ("not_included", "not_conv_or_relu")
-
-    with pytest.warns(RuntimeWarning):
-        paper.style_loss(layers=layers)
-
-    assert mock.call_args[1]["layer_weights"] == "mean"
 
 
 def test_perceptual_loss(subtests):

--- a/tests/unit/gatys_ecker_bethge_2016/test_nst.py
+++ b/tests/unit/gatys_ecker_bethge_2016/test_nst.py
@@ -20,8 +20,11 @@ def test_nst_smoke(subtests, mocker, content_image, style_image):
     args, kwargs = mock.call_args
     input_image, criterion = args
     get_optimizer = kwargs["get_optimizer"]
+    num_steps = kwargs["num_steps"]
     preprocessor = kwargs["preprocessor"]
     postprocessor = kwargs["postprocessor"]
+
+    hyper_parameters = paper.hyper_parameters().nst
 
     with subtests.test("input_image"):
         ptu.assert_allclose(input_image, content_image)
@@ -33,6 +36,9 @@ def test_nst_smoke(subtests, mocker, content_image, style_image):
         assert is_callable(get_optimizer)
         optimizer = get_optimizer(input_image)
         assert isinstance(optimizer, type(paper.optimizer(input_image)))
+
+    with subtests.test("num_steps"):
+        assert num_steps == hyper_parameters.num_steps
 
     with subtests.test("preprocessor"):
         assert isinstance(preprocessor, type(paper.preprocessor()))

--- a/tests/unit/gatys_ecker_bethge_2016/test_utils.py
+++ b/tests/unit/gatys_ecker_bethge_2016/test_utils.py
@@ -6,6 +6,7 @@ from torch import nn, optim
 import pystiche_papers.gatys_ecker_bethge_2016 as paper
 from pystiche import enc, meta
 from pystiche.image import transforms
+from pystiche_papers.utils import HyperParameters
 
 from tests import mocks
 
@@ -79,7 +80,9 @@ def test_compute_layer_weights():
     multi_layer_encoder = enc.MultiLayerEncoder(modules)
     layers, _ = zip(*modules)
 
-    layer_weights = paper.compute_layer_weights(multi_layer_encoder, layers)
+    layer_weights = paper.compute_layer_weights(
+        layers, multi_layer_encoder=multi_layer_encoder
+    )
     assert layer_weights == pytest.approx([1 / n ** 2 for n in out_channels])
 
 
@@ -88,11 +91,23 @@ def test_get_layer_weights_wrong_layers(subtests):
 
     with subtests.test("layer not in multi_layer_encoder"):
         with pytest.raises(ValueError):
-            paper.compute_layer_weights(multi_layer_encoder, ("not_included",))
+            paper.compute_layer_weights(
+                ("not_included",), multi_layer_encoder=multi_layer_encoder
+            )
 
     with subtests.test("no out_channels"):
         with pytest.raises(RuntimeError):
-            paper.compute_layer_weights(multi_layer_encoder, ("relu",))
+            paper.compute_layer_weights(
+                ("relu",), multi_layer_encoder=multi_layer_encoder
+            )
+
+
+def test_hyper_parameters(subtests):
+    hyper_parameters = paper.hyper_parameters()
+    assert isinstance(hyper_parameters, HyperParameters)
+
+    with subtests.test("image_size"):
+        assert hyper_parameters.image_size == 500
 
 
 def test_hyper_parameters_content_loss(subtests):

--- a/tests/unit/gatys_ecker_bethge_2016/test_utils.py
+++ b/tests/unit/gatys_ecker_bethge_2016/test_utils.py
@@ -66,3 +66,93 @@ def test_optimizer(subtests, input_image):
     with subtests.test(msg="optimizer properties"):
         assert param_group["lr"] == ptu.approx(1.0)
         assert param_group["max_iter"] == 1
+
+
+def test_hyper_parameters_content_loss(subtests):
+    hyper_parameters = paper.hyper_parameters()
+
+    sub_params = "content_loss"
+    assert sub_params in hyper_parameters
+    hyper_parameters = getattr(hyper_parameters, sub_params)
+
+    with subtests.test("layer"):
+        assert hyper_parameters.layer == "relu4_2"
+
+    with subtests.test("score_weight"):
+        assert hyper_parameters.score_weight == pytest.approx(1e0)
+
+
+def test_hyper_parameters_style_loss(subtests):
+    hyper_parameters = paper.hyper_parameters()
+
+    sub_params = "style_loss"
+    assert sub_params in hyper_parameters
+    hyper_parameters = getattr(hyper_parameters, sub_params)
+
+    layers, num_channels = zip(
+        ("relu1_1", 64),
+        ("relu2_1", 128),
+        ("relu3_1", 256),
+        ("relu4_1", 512),
+        ("relu5_1", 512),
+    )
+
+    with subtests.test("layer"):
+        assert hyper_parameters.layers == layers
+
+    with subtests.test("layer_weights"):
+        assert hyper_parameters.layer_weights == pytest.approx(
+            [1 / n ** 2 for n in num_channels]
+        )
+
+    with subtests.test("score_weight"):
+        assert hyper_parameters.score_weight == pytest.approx(1e3)
+
+
+def test_hyper_parameters_nst(subtests):
+    hyper_parameters = paper.hyper_parameters()
+
+    sub_params = "nst"
+    assert sub_params in hyper_parameters
+    hyper_parameters = getattr(hyper_parameters, sub_params)
+
+    with subtests.test("num_steps"):
+        assert hyper_parameters.num_steps == 500
+
+
+# def test_get_layer_weights():
+#     layers, nums_channels = zip(
+#         ("relu1_1", 64),
+#         ("relu2_1", 128),
+#         ("relu3_1", 256),
+#         ("relu4_1", 512),
+#         ("relu5_1", 512),
+#     )
+#
+#     actual = get_layer_weights(layers)
+#     desired = tuple(1.0 / num_channels ** 2.0 for num_channels in nums_channels)
+#     assert actual == pytest.approx(desired)
+#
+#
+# def test_get_layer_weights_wrong_layers(subtests):
+#     with subtests.test("layer not in multi_layer_encoder"):
+#         not_included_layers = ("not_included",)
+#
+#         with pytest.raises(RuntimeError):
+#             get_layer_weights(not_included_layers)
+#
+#     with subtests.test("no conv or relu layer"):
+#         no_conv_or_relu_layers = ("pool1",)
+#
+#         with pytest.raises(RuntimeError):
+#             get_layer_weights(no_conv_or_relu_layers)
+#
+# def test_style_loss_wrong_layers(mocker):
+#     mock = mocker.patch("pystiche_papers.gatys_ecker_bethge_2016._loss.StyleLoss")
+#
+#     layers = ("not_included", "not_conv_or_relu")
+#
+#     with pytest.warns(RuntimeWarning):
+#         paper.style_loss(layers=layers)
+#
+#     assert mock.call_args[1]["layer_weights"] == "mean"

--- a/tests/unit/gatys_et_al_2017/conftest.py
+++ b/tests/unit/gatys_et_al_2017/conftest.py
@@ -8,10 +8,10 @@ from tests import mocks
 @pytest.fixture(scope="package", autouse=True)
 def multi_layer_encoder(package_mocker):
     return mocks.patch_multi_layer_encoder_loader(
-        target=mocks.make_mock_target(
+        targets=mocks.make_mock_target(
             "gatys_et_al_2017", "_loss", "_multi_layer_encoder"
         ),
         loader=paper.multi_layer_encoder,
-        setup=((), {}),
+        setups=((), {}),
         mocker=package_mocker,
     )

--- a/tests/unit/johnson_alahi_li_2016/conftest.py
+++ b/tests/unit/johnson_alahi_li_2016/conftest.py
@@ -22,10 +22,10 @@ def styles():
 @pytest.fixture(scope="package", autouse=True)
 def multi_layer_encoder(package_mocker):
     return mocks.patch_multi_layer_encoder_loader(
-        target=mocks.make_mock_target(
+        targets=mocks.make_mock_target(
             "johnson_alahi_li_2016", "_loss", "_multi_layer_encoder"
         ),
         loader=paper.multi_layer_encoder,
-        setup=((), {"impl_params": True}),
+        setups=((), {"impl_params": True}),
         mocker=package_mocker,
     )

--- a/tests/unit/li_wand_2016/conftest.py
+++ b/tests/unit/li_wand_2016/conftest.py
@@ -8,8 +8,8 @@ from tests import mocks
 @pytest.fixture(scope="package", autouse=True)
 def multi_layer_encoder(package_mocker):
     return mocks.patch_multi_layer_encoder_loader(
-        target=mocks.make_mock_target("li_wand_2016", "_loss", "_multi_layer_encoder"),
+        targets=mocks.make_mock_target("li_wand_2016", "_loss", "_multi_layer_encoder"),
         loader=paper.multi_layer_encoder,
-        setup=((), {}),
+        setups=((), {}),
         mocker=package_mocker,
     )

--- a/tests/unit/ulyanov_et_al_2016/conftest.py
+++ b/tests/unit/ulyanov_et_al_2016/conftest.py
@@ -8,10 +8,10 @@ from tests import mocks
 @pytest.fixture(scope="package", autouse=True)
 def multi_layer_encoder(package_mocker):
     return mocks.patch_multi_layer_encoder_loader(
-        target=mocks.make_mock_target(
+        targets=mocks.make_mock_target(
             "ulyanov_et_al_2016", "_loss", "_multi_layer_encoder"
         ),
         loader=paper.multi_layer_encoder,
-        setup=((), {}),
+        setups=((), {}),
         mocker=package_mocker,
     )

--- a/tests/unit/utils/test_hyper_params.py
+++ b/tests/unit/utils/test_hyper_params.py
@@ -15,11 +15,30 @@ def test_HyperParameters_getattr(params):
         assert getattr(hyper_parameters, name) == val
 
 
-def test_HyperParameters_getattr_no_attribute():
+def test_HyperParameters_getattr_unknown_attribute():
     hyper_parameters = HyperParameters()
 
     with pytest.raises(AttributeError):
-        hyper_parameters.unknown_attribute
+        getattr(hyper_parameters, "unknown_attribute")
+
+
+def test_HyperParameters_delattr(params):
+    hyper_parameters = HyperParameters(**params)
+
+    for name in params.keys():
+        getattr(hyper_parameters, name)
+
+        delattr(hyper_parameters, name)
+
+        with pytest.raises(AttributeError):
+            getattr(hyper_parameters, name)
+
+
+def test_HyperParameters_delattr_unknown_attr(params):
+    hyper_parameters = HyperParameters()
+
+    with pytest.raises(AttributeError):
+        delattr(hyper_parameters, "unknown_attribute")
 
 
 def test_HyperParameters_contains(params):

--- a/tests/unit/utils/test_hyper_params.py
+++ b/tests/unit/utils/test_hyper_params.py
@@ -41,7 +41,7 @@ def test_HyperParameters_named_children(params):
     named_children = tuple(hyper_parameters.named_children())
     assert not named_children
 
-    name = "nested_hyper_parameters"
+    name = tuple(params.keys())[0]
     val = HyperParameters()
     setattr(hyper_parameters, name, val)
 

--- a/tests/unit/utils/test_hyper_params.py
+++ b/tests/unit/utils/test_hyper_params.py
@@ -1,0 +1,51 @@
+import pytest
+
+from pystiche_papers.utils import HyperParameters
+
+
+@pytest.fixture
+def params():
+    return {name: val for val, name in enumerate("abc")}
+
+
+def test_HyperParameters_getattr(params):
+    hyper_parameters = HyperParameters(**params)
+
+    for name, val in params.items():
+        assert getattr(hyper_parameters, name) == val
+
+
+def test_HyperParameters_getattr_no_attribute():
+    hyper_parameters = HyperParameters()
+
+    with pytest.raises(AttributeError):
+        hyper_parameters.unknown_attribute
+
+
+def test_HyperParameters_contains(params):
+    hyper_parameters = HyperParameters(**params)
+
+    for name, val in params.items():
+        assert name in hyper_parameters
+
+
+def test_HyperParameters_properties(params):
+    hyper_parameters = HyperParameters(**params)
+
+    assert dict(hyper_parameters.properties()) == params
+
+
+def test_HyperParameters_named_children(params):
+    hyper_parameters = HyperParameters(**params)
+
+    named_children = tuple(hyper_parameters.named_children())
+    assert not named_children
+
+    name = "nested_hyper_parameters"
+    val = HyperParameters()
+    setattr(hyper_parameters, name, val)
+
+    named_children = tuple(hyper_parameters.named_children())
+    assert len(named_children) == 1
+    assert named_children[0][0] == name
+    assert named_children[0][1] is val


### PR DESCRIPTION
Addresses #167

This adds the `HyperParameters` class that should be used to hold all hyper parameters of a paper. For the proof of concept I'm applying this only to `gatys_ecker_bethge_2016` for now.

# ToDo:

- [x] add tests for `HyperParameters`
