### PR TITLE
add data augmentation to sanakoyeu_et_al_2018

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -29,3 +29,6 @@ warn_unused_ignores = False
 
 [mypy-torchvision.*]
 ignore_missing_imports = True
+
+[mypy-kornia.*]
+ignore_missing_imports = True

--- a/pystiche_papers/sanakoyeu_et_al_2018/__init__.py
+++ b/pystiche_papers/sanakoyeu_et_al_2018/__init__.py
@@ -1,3 +1,4 @@
+from ._augmentation import *
 from ._data import *
 from ._modules import *
 from ._utils import *

--- a/pystiche_papers/sanakoyeu_et_al_2018/_augmentation.py
+++ b/pystiche_papers/sanakoyeu_et_al_2018/_augmentation.py
@@ -1,0 +1,469 @@
+from typing import Any, Dict, List, Tuple, Union, cast
+
+import kornia
+import kornia.augmentation.functional as F
+from kornia.augmentation.random_generator import _adapted_uniform, random_prob_generator
+
+import torch
+from torch import nn
+from torch.nn.functional import pad
+
+import pystiche
+from pystiche.image import extract_image_size
+from pystiche.misc import to_2d_arg
+
+__all__ = ["augmentation"]
+
+
+class AugmentationBase(pystiche.ComplexObject, kornia.augmentation.AugmentationBase):
+    def _properties(self) -> Dict[str, Any]:
+        dct = super()._properties()
+        if self.return_transform:
+            dct["return_transform"] = True
+        return dct
+
+
+class RandomRescale(AugmentationBase):
+    def __init__(
+        self,
+        factor: Union[Tuple[float, float], float],
+        probability: float = 50e-2,
+        interpolation: str = "bilinear",
+        align_corners: bool = False,
+    ):
+        super().__init__(return_transform=False)
+        # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L65-L66 # noqa: W505
+        # due to a bug we don't need to randomly chose the factor but only if a
+        # scaling is happening
+        self.factor = to_2d_arg(factor)
+        self.probability = probability
+        self.interpolation = interpolation
+        self.align_corners = align_corners
+        self.same_on_batch = True
+
+    def generate_parameters(self, input_shape: torch.Size) -> Dict[str, torch.Tensor]:
+        return cast(
+            Dict[str, torch.Tensor],
+            random_prob_generator(1, self.probability, self.same_on_batch),
+        )
+
+    def compute_transformation(
+        self, input: torch.Tensor, params: Dict[str, torch.Tensor]
+    ) -> torch.Tensor:
+        raise RuntimeError
+
+    def apply_transform(
+        self, input: torch.Tensor, params: Dict[str, torch.Tensor]
+    ) -> torch.Tensor:
+        if not params["batch_prob"].item():
+            return input
+
+        height, width = extract_image_size(input)
+        factor_vert, factor_horz = self.factor
+        size = (int(height * factor_vert), width * factor_horz)
+        return cast(
+            torch.Tensor,
+            kornia.resize(
+                input,
+                size,
+                interpolation=self.interpolation,
+                align_corners=self.align_corners,
+            ),
+        )
+
+    def _properties(self) -> Dict[str, Any]:
+        dct = super()._properties()
+        dct["factor"] = self.factor
+        dct["probability"] = f"{self.probability:.1%}"
+        if self.interpolation != "bilinear":
+            dct["interpolation"] = self.interpolation
+        if self.same_on_batch:
+            dct["same_on_batch"] = True
+        if self.align_corners:
+            dct["align_corners"] = True
+        return dct
+
+
+class RandomRotation(pystiche.ComplexObject, kornia.augmentation.RandomRotation):
+    def __init__(
+        self,
+        degrees: Union[torch.Tensor, float, Tuple[float, float], List[float]],
+        probability: float = 50e-2,
+        interpolation: str = "bilinear",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(degrees, interpolation=interpolation, **kwargs)
+        self.probability = probability
+
+    def generate_parameters(self, batch_shape: torch.Size) -> Dict[str, torch.Tensor]:
+        batch_params = cast(
+            Dict[str, torch.Tensor],
+            random_prob_generator(batch_shape[0], self.probability, self.same_on_batch),
+        )
+        params = cast(Dict[str, torch.Tensor], super().generate_parameters(batch_shape))
+        params["degrees"][batch_params["batch_prob"]] = 0.0
+        return params
+
+    def _properties(self) -> Dict[str, Any]:
+        dct = super()._properties()
+        dct["degrees"] = self.degrees
+        dct["probability"] = f"{self.probability:.1%}"
+        if self.interpolation != "bilinear":
+            dct["interpolation"] = self.interpolation
+        if self.same_on_batch:
+            dct["same_on_batch"] = True
+        if self.align_corners:
+            dct["align_corners"] = True
+        return dct
+
+
+def affine_matrix_from_three_points(
+    points: torch.Tensor, transformed_points: torch.Tensor
+) -> torch.Tensor:
+    mat1 = transformed_points
+    mat2 = torch.inverse(torch.cat((points, torch.ones(points.size()[0], 1, 3))))
+    return torch.bmm(mat1, mat2)
+
+
+class RandomAffine(AugmentationBase):
+    def __init__(
+        self,
+        shift: float,
+        probability: float = 50e-2,
+        interpolation: str = "bilinear",
+        same_on_batch: bool = False,
+        align_corners: bool = False,
+    ):
+        super().__init__(return_transform=False)
+        self.shift = shift
+        self.probability = probability
+        self.interpolation = interpolation
+        self.same_on_batch = same_on_batch
+        self.align_corners = align_corners
+
+    def generate_parameters(self, input_shape: torch.Size) -> Dict[str, torch.Tensor]:
+        batch_size = input_shape[0]
+        batch_params = cast(
+            Dict[str, torch.Tensor],
+            random_prob_generator(batch_size, self.probability, self.same_on_batch),
+        )
+
+        points = torch.tensor((((0, 0, 1), (0, 1, 0)),), dtype=torch.float).repeat(
+            batch_size, 1, 1
+        )
+        shift = _adapted_uniform(
+            points.size(), -self.shift, self.shift, same_on_batch=self.same_on_batch
+        )
+        shift[~batch_params["batch_prob"], ...] = 0.0
+
+        return {"matrix": affine_matrix_from_three_points(points, points + shift)}
+
+    def apply_transform(
+        self, input: torch.Tensor, params: Dict[str, torch.Tensor]
+    ) -> torch.Tensor:
+        return cast(
+            torch.Tensor,
+            F.warp_affine(
+                input,
+                params["matrix"],
+                extract_image_size(input),
+                flags=self.interpolation,
+                align_corners=self.align_corners,
+            ),
+        )
+
+    def _properties(self) -> Dict[str, Any]:
+        dct = super()._properties()
+        dct["shift"] = self.shift
+        dct["probability"] = f"{self.probability:.1%}"
+        if self.interpolation != "bilinear":
+            dct["interpolation"] = self.interpolation
+        if self.same_on_batch:
+            dct["same_on_batch"] = True
+        if self.align_corners:
+            dct["align_corners"] = True
+        return dct
+
+
+def _adapted_uniform_int(
+    shape: Union[Tuple, torch.Size],
+    low: Union[float, torch.Tensor],
+    high: Union[float, torch.Tensor],
+    same_on_batch: bool = False,
+) -> torch.Tensor:
+    return cast(
+        torch.Tensor, _adapted_uniform(shape, low, high + 1 - 1e-6, same_on_batch).int()
+    )
+
+
+class RandomCrop(AugmentationBase):
+    def __init__(
+        self,
+        size: Union[Tuple[int, int], int],
+        interpolation: str = "bilinear",
+        return_transform: bool = False,
+        same_on_batch: bool = False,
+        align_corners: bool = False,
+    ) -> None:
+        super().__init__(return_transform=return_transform)
+        self.size = cast(Tuple[int, int], to_2d_arg(size))
+        self.interpolation = interpolation
+        self.same_on_batch = same_on_batch
+        self.align_corners = align_corners
+
+    def generate_parameters(self, input_shape: torch.Size) -> Dict[str, torch.Tensor]:
+        batch_size = input_shape[0]
+        image_size = cast(Tuple[int, int], input_shape[-2:])
+        anchors = self.generate_anchors(
+            batch_size, image_size, self.size, self.same_on_batch
+        )
+        dst = self.generate_vertices_from_size(batch_size, self.size)
+        src = self.clamp_vertices_to_size(anchors + dst, image_size)
+        return dict(
+            src=src,
+            dst=dst,
+            interpolation=torch.tensor(kornia.Resample.get(self.interpolation).value),
+            align_corners=torch.tensor(self.align_corners),
+        )
+
+    def compute_transformation(
+        self, input: torch.Tensor, params: Dict[str, torch.Tensor]
+    ) -> torch.Tensor:
+        return cast(torch.Tensor, F.compute_crop_transformation(input, params))
+
+    def apply_transform(
+        self, input: torch.Tensor, params: Dict[str, torch.Tensor]
+    ) -> torch.Tensor:
+        return cast(torch.Tensor, F.apply_crop(input, params))
+
+    @staticmethod
+    def generate_anchors(
+        batch_size: int,
+        image_size: Tuple[int, int],
+        crop_size: Tuple[int, int],
+        same_on_batch: bool,
+    ) -> torch.Tensor:
+        def generate_single_dim_anchor(
+            batch_size: int, image_length: int, crop_length: int, same_on_batch: bool
+        ) -> torch.Tensor:
+            diff = image_length - crop_length
+            if diff <= 0:
+                return torch.zeros((batch_size,), dtype=torch.int)
+            else:
+                return _adapted_uniform_int((batch_size,), 0, diff, same_on_batch)
+
+        single_dim_anchors = [
+            generate_single_dim_anchor(
+                batch_size, image_length, crop_length, same_on_batch
+            )
+            for image_length, crop_length in zip(image_size, crop_size)
+        ]
+        return torch.stack(single_dim_anchors, dim=1,).unsqueeze(1).repeat(1, 4, 1)
+
+    @staticmethod
+    def generate_vertices_from_size(
+        batch_size: int, size: Tuple[int, int]
+    ) -> torch.Tensor:
+        height, width = size
+        return (
+            torch.tensor(
+                ((0, 0), (width - 1, 0), (width - 1, height - 1), (0, height - 1),),
+                dtype=torch.int,
+            )
+            .unsqueeze(0)
+            .repeat(batch_size, 1, 1)
+        )
+
+    @staticmethod
+    def clamp_vertices_to_size(
+        vertices: torch.Tensor, size: Tuple[int, int]
+    ) -> torch.Tensor:
+        horz, vert = vertices.split(1, dim=2)
+        height, width = size
+        return torch.cat(
+            (torch.clamp(horz, 0, width - 1), torch.clamp(vert, 0, height - 1),), dim=2,
+        )
+
+    def _properties(self) -> Dict[str, Any]:
+        dct = super()._properties()
+        dct["size"] = self.size
+        if self.interpolation != "bilinear":
+            dct["interpolation"] = self.interpolation
+        if self.same_on_batch:
+            dct["same_on_batch"] = True
+        if self.align_corners:
+            dct["align_corners"] = True
+        return dct
+
+
+Range = Union[torch.Tensor, float, Tuple[float, float], List[float]]
+
+
+def _range_to_bounds(range: Range) -> Tuple[float, float]:
+    if isinstance(range, int):
+        range = float(range)
+    if isinstance(range, float):
+        if range < 0.0:
+            raise ValueError
+        return (-range, range)
+
+    if isinstance(range, torch.Tensor):
+        range = torch.flatten(range).tolist()
+
+    if not isinstance(range, (tuple, list)):
+        raise TypeError
+
+    if len(range) != 2:
+        raise ValueError
+
+    return cast(Tuple[int, int], tuple(float(item) for item in range))
+
+
+def random_hsv_jitter_generator(
+    batch_size: int,
+    same_on_batch: bool,
+    hue_scale: Range,
+    hue_shift: Range,
+    saturation_scale: Range,
+    saturation_shift: Range,
+    value_scale: Range,
+    value_shift: Range,
+) -> Dict[str, torch.Tensor]:
+    def generate(range: Range, shift: bool) -> torch.Tensor:
+        low, high = _range_to_bounds(range)
+        if not shift:
+            low = 1.0 / (1.0 - low)
+            high = 1.0 + high
+        value = cast(
+            torch.Tensor,
+            _adapted_uniform((batch_size,), low, high, same_on_batch=same_on_batch),
+        )
+        return value.view(-1, 1, 1, 1)
+
+    parameters = {}
+    for parameter in ("hue", "saturation", "value"):
+        for shift in (False, True):
+            name = f"{parameter}_{'shift' if shift else 'scale'}"
+            range = locals()[name]
+            parameters[name] = generate(range, shift)
+    return parameters
+
+
+def apply_hsv_jitter(
+    input: torch.Tensor, params: Dict[str, torch.Tensor]
+) -> torch.Tensor:
+    h, s, v = torch.split(kornia.rgb_to_hsv(input), 1, dim=1)
+    h = torch.clamp(
+        h * params["hue_scale"] + params["hue_shift"],
+        1e-2 * 2.0 * kornia.pi,
+        99e-2 * 2.0 * kornia.pi,
+    )
+    s = torch.clamp(
+        h * params["saturation_scale"] + params["saturation_shift"], 1e-2, 99e-2,
+    )
+    v = torch.clamp(h * params["value_scale"] + params["value_shift"], 1e-2, 99e-2,)
+    return cast(torch.Tensor, kornia.hsv_to_rgb(torch.cat((h, s, v), dim=1)))
+
+
+class RandomHSVJitter(AugmentationBase):
+    def __init__(
+        self,
+        hue_scale: Range,
+        hue_shift: Range,
+        saturation_scale: Range,
+        saturation_shift: Range,
+        value_scale: Range,
+        value_shift: Range,
+        same_on_batch: bool = False,
+    ):
+        super().__init__(return_transform=False)
+        self.hue_scale = hue_scale
+        self.hue_shift = hue_shift
+        self.saturation_scale = saturation_scale
+        self.saturation_shift = saturation_shift
+        self.value_scale = value_scale
+        self.value_shift = value_shift
+        self.same_on_batch = same_on_batch
+
+    def generate_parameters(self, input_shape: torch.Size) -> Dict[str, torch.Tensor]:
+        return random_hsv_jitter_generator(
+            input_shape[0],
+            self.same_on_batch,
+            self.hue_scale,
+            self.hue_shift,
+            self.saturation_scale,
+            self.saturation_shift,
+            self.value_scale,
+            self.value_shift,
+        )
+
+    def apply_transform(
+        self, input: torch.Tensor, params: Dict[str, torch.Tensor]
+    ) -> torch.Tensor:
+        return apply_hsv_jitter(input, params)
+
+
+def compute_relative_pad_size(
+    image: torch.Tensor, factor: Tuple[float, float]
+) -> Tuple[int, int]:
+    height, width = extract_image_size(image)
+    vert_factor, horz_factor = factor
+    return int(height * vert_factor), int(height * horz_factor)
+
+
+class DynamicSizeReflectionPad2d(nn.Module):
+    def __init__(self, factor: Union[Tuple[float, float], float]):
+        super().__init__()
+        self.factor = cast(Tuple[int, int], to_2d_arg(factor))
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        vert_pad, horz_pad = compute_relative_pad_size(input, self.factor)
+        pad_ = [horz_pad, horz_pad, vert_pad, vert_pad]
+        return pad(input, pad_, mode="reflect")
+
+
+class RemoveDynamicSizePadding(nn.Module):
+    def __init__(self, factor: Union[Tuple[float, float], float]):
+        super().__init__()
+        self.factor = to_2d_arg(factor)
+
+    @property
+    def inverse_factor(self) -> Tuple[float, float]:
+        return cast(
+            Tuple[float, float], tuple(factor / (1 + factor) for factor in self.factor)
+        )
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        height, width = extract_image_size(input)
+        vert_pad, horz_pad = compute_relative_pad_size(input, self.inverse_factor)
+        crop_size = (height - vert_pad, width - horz_pad)
+        return cast(torch.Tensor, kornia.center_crop(input, crop_size))
+
+
+def augmentation(
+    size: Union[Tuple[int, int], int] = (768, 768),
+    probability: float = 50e-2,
+    same_on_batch: bool = True,
+) -> nn.Sequential:
+    return nn.Sequential(
+        RandomRescale(factor=80e-2, probability=probability, interpolation="bicubic"),
+        DynamicSizeReflectionPad2d(factor=25e-2),
+        RandomRotation(
+            degrees=0.15 * 90, probability=probability, same_on_batch=same_on_batch
+        ),
+        RandomAffine(5e-2, probability=probability, same_on_batch=same_on_batch),
+        RemoveDynamicSizePadding(factor=25e-2),
+        RandomCrop(size, same_on_batch=same_on_batch),
+        RandomHSVJitter(
+            hue_scale=0e-2,
+            hue_shift=5e-2,
+            saturation_scale=5e-2,
+            saturation_shift=5e-2,
+            value_scale=5e-2,
+            value_shift=5e-2,
+            same_on_batch=same_on_batch,
+        ),
+        kornia.augmentation.RandomHorizontalFlip(
+            p=probability, same_on_batch=same_on_batch
+        ),
+    )

--- a/pystiche_papers/sanakoyeu_et_al_2018/_augmentation.py
+++ b/pystiche_papers/sanakoyeu_et_al_2018/_augmentation.py
@@ -11,6 +11,7 @@ from torch.nn.functional import pad
 import pystiche
 from pystiche.image import extract_image_size
 from pystiche.misc import to_2d_arg
+from pystiche_papers.utils import pad_size_to_pad
 
 __all__ = ["augmentation"]
 
@@ -449,7 +450,7 @@ class DynamicSizePad2d(pystiche.Module):
         height, width = size
         vert_factor, horz_factor = self.factor
         pad_size = int(height * vert_factor), int(height * horz_factor)
-        return pad(input, self._compute_pad(pad_size), mode=self.mode, value=self.value)
+        return pad(input, pad_size_to_pad(pad_size), mode=self.mode, value=self.value)
 
     @staticmethod
     def _compute_pad(pad_size: Tuple[int, int]) -> List[int]:

--- a/pystiche_papers/sanakoyeu_et_al_2018/_data.py
+++ b/pystiche_papers/sanakoyeu_et_al_2018/_data.py
@@ -86,24 +86,22 @@ class ClampSize(transforms.Transform):
 
 
 def style_image_transform(
-    impl_params: bool = True, edge_size: int = 768, train: bool = False
+    impl_params: bool = True,
+    image_size: Tuple[int, int] = (768, 768),
+    train: bool = False,
 ) -> nn.Sequential:
     transforms_: List[nn.Module] = [
         ClampSize(),
-        transforms.ValidRandomCrop((edge_size, edge_size)),
+        transforms.ValidRandomCrop(image_size),
         OptionalGrayscaleToFakegrayscale(),
     ]
     if impl_params and train:
-        transforms_.append(augmentation(size=edge_size))
+        transforms_.append(augmentation(image_size=image_size))
     return nn.Sequential(*transforms_)
 
 
-def content_image_transform(
-    impl_params: bool = True, edge_size: int = 768, train: bool = False,
-) -> nn.Sequential:
-    transform = style_image_transform(
-        impl_params=impl_params, edge_size=edge_size, train=train
-    )
+def content_image_transform(impl_params: bool = True, **kwargs: Any) -> nn.Sequential:
+    transform = style_image_transform(impl_params=impl_params, **kwargs)
     if not impl_params:
         return transform
 

--- a/pystiche_papers/sanakoyeu_et_al_2018/_data.py
+++ b/pystiche_papers/sanakoyeu_et_al_2018/_data.py
@@ -85,13 +85,15 @@ class ClampSize(transforms.Transform):
         return dct
 
 
-def style_image_transform(edge_size: int = 768, train: bool = False) -> nn.Sequential:
+def style_image_transform(
+    impl_params: bool = True, edge_size: int = 768, train: bool = False
+) -> nn.Sequential:
     transforms_: List[nn.Module] = [
         ClampSize(),
         transforms.ValidRandomCrop((edge_size, edge_size)),
         OptionalGrayscaleToFakegrayscale(),
     ]
-    if train:
+    if impl_params and train:
         transforms_.append(augmentation(size=edge_size))
     return nn.Sequential(*transforms_)
 
@@ -99,11 +101,13 @@ def style_image_transform(edge_size: int = 768, train: bool = False) -> nn.Seque
 def content_image_transform(
     impl_params: bool = True, edge_size: int = 768, train: bool = False,
 ) -> nn.Sequential:
-    transform = style_image_transform(edge_size=edge_size, train=train)
+    transform = style_image_transform(
+        impl_params=impl_params, edge_size=edge_size, train=train
+    )
     if not impl_params:
         return transform
 
-    return nn.Sequential(transforms.Rescale(2.0), *transform.children())
+    return nn.Sequential(transforms.Rescale(2.0), transform)
 
 
 class WikiArt(ImageFolderDataset):

--- a/pystiche_papers/utils/misc.py
+++ b/pystiche_papers/utils/misc.py
@@ -38,6 +38,7 @@ __all__ = [
     "save_state_dict",
     "load_state_dict_from_url",
     "channel_progression",
+    "pad_size_to_pad",
 ]
 
 
@@ -208,3 +209,11 @@ def channel_progression(
     return [
         module_fn(*channels_pair) for channels_pair in more_itertools.pairwise(channels)
     ]
+
+
+def pad_size_to_pad(pad_size: Union[Sequence[int], torch.Tensor]) -> List[int]:
+    if not isinstance(pad_size, torch.Tensor):
+        pad_size = torch.tensor(pad_size)
+    pad_post = pad_size // 2
+    pad_pre = pad_size - pad_post
+    return torch.stack((pad_pre, pad_post), dim=1).view(-1).flip(0).tolist()

--- a/pystiche_papers/utils/modules.py
+++ b/pystiche_papers/utils/modules.py
@@ -10,6 +10,8 @@ from torch.nn.modules.pooling import _AvgPoolNd
 import pystiche
 from pystiche.misc import to_2d_arg
 
+from .misc import pad_size_to_pad
+
 __all__ = [
     "Identity",
     "ResidualBlock",
@@ -59,7 +61,7 @@ class _AutoPadNdMixin(pystiche.ComplexObject):
             raise RuntimeError
         super().__init__(*args, **kwargs)  # type: ignore[call-arg]
 
-        self._pad = self._pad_size_to_pad(self._compute_pad_size())
+        self._pad = pad_size_to_pad(self._compute_pad_size())
 
     @abstractmethod
     def _compute_pad_size(self) -> torch.Tensor:
@@ -69,12 +71,6 @@ class _AutoPadNdMixin(pystiche.ComplexObject):
     @abstractmethod
     def _mode(self) -> str:
         pass
-
-    @staticmethod
-    def _pad_size_to_pad(size: torch.Tensor) -> List[int]:
-        pad_post = size // 2
-        pad_pre = size - pad_post
-        return torch.stack((pad_pre, pad_post), dim=1).view(-1).flip(0).tolist()
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         return cast(

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     # TODO: add a released version of pystiche
     torch >= 1.6
     torchvision >= 0.7
+    kornia >= 0.4
     more_itertools >= 2.5
 
 [options.packages.find]

--- a/tests/unit/sanakoyeu_et_al_2018/test_augmentation.py
+++ b/tests/unit/sanakoyeu_et_al_2018/test_augmentation.py
@@ -1,0 +1,181 @@
+import pytest
+
+import pytorch_testing_utils as ptu
+import torch
+
+import pystiche_papers.sanakoyeu_et_al_2018 as paper
+from pystiche.image import (
+    extract_batch_size,
+    extract_edge_size,
+    extract_image_size,
+    extract_num_channels,
+)
+from pystiche.image.transforms.functional import rescale
+from pystiche_papers import utils
+from pystiche_papers.sanakoyeu_et_al_2018._augmentation import (
+    DynamicSizeReflectionPad2d,
+    RandomAffine,
+    RandomCrop,
+    RandomHSVJitter,
+    RandomRescale,
+    RandomRotation,
+    RemoveDynamicSizePadding,
+)
+
+from tests import mocks
+
+
+def assert_is_size_and_value_range_preserving(input_image, transform):
+    output_image = transform(input_image)
+    size_fmtstr = "The {} of the output and input image mismatch: {} != {}"
+
+    actual = extract_batch_size(output_image)
+    expected = extract_batch_size(input_image)
+    assert actual == expected, size_fmtstr.format("batch sizes", actual, expected)
+
+    actual = extract_num_channels(output_image)
+    expected = extract_num_channels(input_image)
+    assert actual == expected, size_fmtstr.format(
+        "number of channels", actual, expected
+    )
+
+    actual = extract_image_size(output_image)
+    expected = extract_image_size(input_image)
+    assert actual == expected, size_fmtstr.format("image sizes", actual, expected)
+
+    assert torch.all(
+        (output_image >= 0.0) & (output_image <= 1.0)
+    ), "The output image contains values outside of the interval [0.0, 1.0]"
+
+
+def assert_is_noop(input_image, transform, **kwargs):
+    output_image = transform(input_image)
+    ptu.assert_allclose(output_image, input_image, **kwargs)
+
+
+@pytest.fixture(autouse=True)
+def make_reproducible():
+    utils.make_reproducible(0)
+
+
+@pytest.fixture
+def patch_random_prob_generator(mocker):
+    def patch_random_prob_generator(outputs, batch_size=None):
+        if isinstance(outputs, bool):
+            outputs = [outputs] * (batch_size or 1)
+        return mocker.patch(
+            mocks.make_mock_target(
+                "sanakoyeu_et_al_2018", "_augmentation", "random_prob_generator"
+            ),
+            return_value=dict(batch_prob=torch.tensor(outputs)),
+        )
+
+    return patch_random_prob_generator
+
+
+def test_RandomRescale(input_image):
+    factor = 0.5
+    transform = RandomRescale(factor, probability=100e-2)
+
+    actual = transform(input_image)
+    expected = rescale(input_image, factor)
+    ptu.assert_allclose(actual, expected)
+
+
+def test_RandomRescale_noop(subtests, input_image):
+    for factor, probability in ((1.0, 100e-2), (0.5, 0e-2)):
+        with subtests.test(factor=factor, probability=probability):
+            transform = RandomRescale(factor, probability=probability)
+            assert_is_noop(input_image, transform)
+
+
+def test_RandomRotation_smoke(input_image):
+    degrees = 30.0
+    transform = RandomRotation(degrees, probability=100e-2)
+    assert_is_size_and_value_range_preserving(input_image, transform)
+
+
+def test_RandomRotation_noop(subtests, input_image):
+    for degrees, probability in ((0.0, 100e-2), (30.0, 0e-2)):
+        with subtests.test(degrees=degrees, probability=probability):
+            transform = RandomRotation(degrees, probability=probability)
+            assert_is_noop(input_image, transform)
+
+
+def test_RandomAffine_smoke(input_image):
+    shift = 0.2
+    transform = RandomAffine(shift, probability=100e-2)
+    assert_is_size_and_value_range_preserving(input_image, transform)
+
+
+def test_RandomAffine_noop(subtests, input_image):
+    for shift, probability in ((0.0, 100e-2), (0.2, 0e-2)):
+        with subtests.test(degrees=shift, probability=probability):
+            transform = RandomAffine(shift, probability=probability)
+            assert_is_noop(input_image, transform)
+
+
+def test_RandomCrop_smoke(input_image):
+    size = extract_image_size(input_image)
+    transform = RandomCrop(size)
+    assert_is_size_and_value_range_preserving(input_image, transform)
+
+
+def test_RandomCrop_size(input_image):
+    size = extract_edge_size(input_image) // 2
+    transform = RandomCrop(size)
+
+    output_image = transform(input_image)
+    assert extract_edge_size(output_image) == size
+
+
+def test_RandomHSVJitter_smoke(input_image):
+    scale = shift = 0.2
+    transform = RandomHSVJitter(
+        hue_scale=scale,
+        hue_shift=shift,
+        saturation_scale=scale,
+        saturation_shift=shift,
+        value_scale=scale,
+        value_shift=shift,
+    )
+    assert_is_size_and_value_range_preserving(input_image, transform)
+
+
+def test_DynamicSizePadding_noop(input_image):
+    factor = 0.5
+    transform = DynamicSizeReflectionPad2d(factor)
+    inverse_transform = RemoveDynamicSizePadding(factor)
+    assert_is_noop(
+        input_image, lambda image: inverse_transform(transform(image)), atol=1e-3
+    )
+
+
+def test_augmentation_smoke(subtests, input_image):
+    size = extract_image_size(input_image)
+    probability = 100e-2
+    same_on_batch = True
+
+    input_image = utils.batch_up_image(input_image, 2)
+
+    utils.make_reproducible()
+    transform = paper.augmentation(
+        size=size, probability=probability, same_on_batch=same_on_batch
+    )
+
+    output_image = transform(input_image)
+
+    with subtests.test("size"):
+        assert output_image.size() == input_image.size()
+
+    with subtests.test("same_on_batch"):
+        samples = torch.split(output_image, 1)
+        for sample in samples[1:]:
+            ptu.assert_allclose(sample, samples[0])
+
+    with subtests.test("value_range"):
+        assert torch.all((output_image >= 0.0) & (output_image <= 1.0))
+
+
+def test_augmentation_repr_smoke():
+    assert isinstance(repr(paper.augmentation()), str)

--- a/tests/unit/sanakoyeu_et_al_2018/test_augmentation.py
+++ b/tests/unit/sanakoyeu_et_al_2018/test_augmentation.py
@@ -22,8 +22,6 @@ from pystiche_papers.sanakoyeu_et_al_2018._augmentation import (
     RemoveDynamicSizePadding,
 )
 
-from tests import mocks
-
 
 def assert_is_size_and_value_range_preserving(input_image, transform):
     output_image = transform(input_image)
@@ -56,21 +54,6 @@ def assert_is_noop(input_image, transform, **kwargs):
 @pytest.fixture(autouse=True)
 def make_reproducible():
     utils.make_reproducible(0)
-
-
-@pytest.fixture
-def patch_random_prob_generator(mocker):
-    def patch_random_prob_generator(outputs, batch_size=None):
-        if isinstance(outputs, bool):
-            outputs = [outputs] * (batch_size or 1)
-        return mocker.patch(
-            mocks.make_mock_target(
-                "sanakoyeu_et_al_2018", "_augmentation", "random_prob_generator"
-            ),
-            return_value=dict(batch_prob=torch.tensor(outputs)),
-        )
-
-    return patch_random_prob_generator
 
 
 def test_RandomRescale(input_image):

--- a/tests/unit/sanakoyeu_et_al_2018/test_augmentation.py
+++ b/tests/unit/sanakoyeu_et_al_2018/test_augmentation.py
@@ -13,13 +13,12 @@ from pystiche.image import (
 from pystiche.image.transforms.functional import rescale
 from pystiche_papers import utils
 from pystiche_papers.sanakoyeu_et_al_2018._augmentation import (
-    DynamicSizeReflectionPad2d,
+    DynamicSizePad2d,
     RandomAffine,
     RandomCrop,
     RandomHSVJitter,
     RandomRescale,
     RandomRotation,
-    RemoveDynamicSizePadding,
 )
 
 
@@ -125,17 +124,14 @@ def test_RandomHSVJitter_smoke(input_image):
     assert_is_size_and_value_range_preserving(input_image, transform)
 
 
-def test_DynamicSizePadding_noop(input_image):
+def test_DynamicSizePad2d(input_image):
     factor = 0.5
-    transform = DynamicSizeReflectionPad2d(factor)
-    inverse_transform = RemoveDynamicSizePadding(factor)
-    assert_is_noop(
-        input_image, lambda image: inverse_transform(transform(image)), atol=1e-3
-    )
+    transform = DynamicSizePad2d(utils.Identity(), factor)
+    assert_is_noop(input_image, transform, atol=1e-3)
 
 
 def test_augmentation_smoke(subtests, input_image):
-    size = extract_image_size(input_image)
+    image_size = extract_image_size(input_image)
     probability = 100e-2
     same_on_batch = True
 
@@ -143,7 +139,7 @@ def test_augmentation_smoke(subtests, input_image):
 
     utils.make_reproducible()
     transform = paper.augmentation(
-        size=size, probability=probability, same_on_batch=same_on_batch
+        image_size=image_size, probability=probability, same_on_batch=same_on_batch
     )
 
     output_image = transform(input_image)

--- a/tests/unit/sanakoyeu_et_al_2018/test_data.py
+++ b/tests/unit/sanakoyeu_et_al_2018/test_data.py
@@ -7,6 +7,7 @@ import pytest
 
 import pytorch_testing_utils as ptu
 import torch
+from torch import nn
 from torch.utils.data import DataLoader
 from torch.utils.data.sampler import RandomSampler
 
@@ -117,6 +118,25 @@ def test_style_image_transform():
     transform = transforms.ValidRandomCrop(edge_size)
     make_reproducible()
     expected = F.grayscale_to_fakegrayscale(transform(image))
+
+    ptu.assert_allclose(actual, expected)
+
+
+def test_style_image_transform_train():
+    edge_size = 16
+    make_reproducible()
+    image = torch.rand(1, 1, 800, 800)
+
+    make_reproducible()
+    image_transform = paper.style_image_transform(edge_size=edge_size, train=True)
+    actual = image_transform(image)
+
+    make_reproducible()
+    transform = nn.Sequential(
+        paper.style_image_transform(edge_size=edge_size, train=False),
+        paper.augmentation(size=edge_size),
+    )
+    expected = transform(image)
 
     ptu.assert_allclose(actual, expected)
 

--- a/tests/unit/sanakoyeu_et_al_2018/test_data.py
+++ b/tests/unit/sanakoyeu_et_al_2018/test_data.py
@@ -107,15 +107,15 @@ def test_ClampSize_repr(subtests):
 
 
 def test_style_image_transform():
-    edge_size = 16
+    image_size = (16, 16)
     make_reproducible()
     image = torch.rand(1, 1, 800, 800)
 
     make_reproducible()
-    image_transform = paper.style_image_transform(edge_size=edge_size)
+    image_transform = paper.style_image_transform(image_size=image_size)
     actual = image_transform(image)
 
-    transform = transforms.ValidRandomCrop(edge_size)
+    transform = transforms.ValidRandomCrop(image_size)
     make_reproducible()
     expected = F.grayscale_to_fakegrayscale(transform(image))
 
@@ -123,18 +123,18 @@ def test_style_image_transform():
 
 
 def test_style_image_transform_augmentation():
-    edge_size = 16
+    image_size = (16, 16)
     make_reproducible()
     image = torch.rand(1, 1, 800, 800)
 
     make_reproducible()
-    image_transform = paper.style_image_transform(edge_size=edge_size, train=True)
+    image_transform = paper.style_image_transform(image_size=image_size, train=True)
     actual = image_transform(image)
 
     make_reproducible()
     transform = nn.Sequential(
-        paper.style_image_transform(edge_size=edge_size, train=False),
-        paper.augmentation(size=edge_size),
+        paper.style_image_transform(image_size=image_size, train=False),
+        paper.augmentation(image_size=image_size),
     )
     expected = transform(image)
 

--- a/tests/unit/sanakoyeu_et_al_2018/test_data.py
+++ b/tests/unit/sanakoyeu_et_al_2018/test_data.py
@@ -122,7 +122,7 @@ def test_style_image_transform():
     ptu.assert_allclose(actual, expected)
 
 
-def test_style_image_transform_train():
+def test_style_image_transform_augmentation():
     edge_size = 16
     make_reproducible()
     image = torch.rand(1, 1, 800, 800)

--- a/tests/unit/utils/test_misc.py
+++ b/tests/unit/utils/test_misc.py
@@ -270,3 +270,14 @@ def test_channel_progression(subtests):
             assert actual.in_channels == desired.in_channels
         with subtests.test("out_channels"):
             assert actual.out_channels == desired.out_channels
+
+
+def test_pad_size_to_pad(subtests):
+    for pad_size, pad in (
+        ((1,), [0, 1]),
+        ((2,), [1, 1]),
+        ((1, 2), [1, 1, 0, 1]),
+        ((1, 2, 3), [1, 2, 1, 1, 0, 1]),
+    ):
+        with subtests.test(pad_size):
+            assert utils.pad_size_to_pad(pad_size) == pad


### PR DESCRIPTION
This adds the image augmentation pipeline that was split off from #162 (and later #177 ). For the augmentation transforms we pull `kornia` as dependency. Given that `pystiche` has already started to replace the custom transforms with `kornia` and it will be a dependency in the future anyway, this should be fine. 

ToDo:

- [x] Tests