### PR TITLE
move download tests for sanakoyeu_et_al_2018

### DIFF
--- a/tests/download/paper/test_sanakoyeu_et_al_2018.py
+++ b/tests/download/paper/test_sanakoyeu_et_al_2018.py
@@ -1,0 +1,13 @@
+import pytest
+
+import pystiche_papers.sanakoyeu_et_al_2018 as paper
+
+from ..asserts import assert_is_downloadable
+
+
+@pytest.mark.slow
+def test_WikiArt_downloadable(subtests):
+    base = paper.WikiArt.BASE_URL
+    styles = paper.WikiArt.STYLES
+    for style in styles:
+        assert_is_downloadable(f"{base}{style}.tar.gz")

--- a/tests/unit/sanakoyeu_et_al_2018/test_data.py
+++ b/tests/unit/sanakoyeu_et_al_2018/test_data.py
@@ -24,7 +24,6 @@ from pystiche_papers.utils import make_reproducible
 
 from . import make_paper_mock_target
 from tests import asserts
-from tests.asserts import assert_is_downloadable
 from tests.utils import make_tar
 
 
@@ -142,14 +141,6 @@ def test_WikiArt_unknown_style(tmpdir):
     style = "unknown"
     with pytest.raises(ValueError):
         paper.style_dataset(tmpdir, style)
-
-
-@pytest.mark.slow
-def test_WikiArt_downloadable(subtests, patch_collect_images, tmpdir):
-    for style in paper.WikiArt.STYLES:
-        with subtests.test(style):
-            dataset = paper.WikiArt(tmpdir, style, download=False)
-            assert_is_downloadable(dataset.url)
 
 
 @pytest.fixture


### PR DESCRIPTION
applies #187 to `sanakoyeu_et_al_2018`