### PR TITLE
fix sanakoyeu_et_al_2018 image transforms

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -29,6 +29,3 @@ warn_unused_ignores = False
 
 [mypy-torchvision.*]
 ignore_missing_imports = True
-
-[mypy-kornia.*]
-ignore_missing_imports = True

--- a/pystiche_papers/sanakoyeu_et_al_2018/_augmentation.py
+++ b/pystiche_papers/sanakoyeu_et_al_2018/_augmentation.py
@@ -329,7 +329,7 @@ def pre_crop_augmentation(
         # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L27
         # The interpolation mode should be "bicubic", but this isn't supported
         # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L113
-        RandomRescale(factor=80e-2, p=p, interpolation="bilinear"),
+        RandomRescale(factor=80e-2, p=p, interpolation="bilinear", align_corners=True),
         # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L71
         # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L82
         DynamicSizePad2d(

--- a/pystiche_papers/sanakoyeu_et_al_2018/_augmentation.py
+++ b/pystiche_papers/sanakoyeu_et_al_2018/_augmentation.py
@@ -2,10 +2,12 @@ from typing import Any, Dict, List, Tuple, Union, cast
 
 import kornia
 import kornia.augmentation.functional as F
-from kornia.augmentation.random_generator import random_prob_generator
+from kornia import augmentation
+from kornia.augmentation.utils import _adapted_uniform
+from kornia.geometry import warp_perspective
 
 import torch
-from torch import distributions, nn
+from torch import nn
 from torch.nn.functional import pad
 
 import pystiche
@@ -16,120 +18,80 @@ from pystiche_papers.utils import pad_size_to_pad
 __all__ = ["pre_crop_augmentation", "post_crop_augmentation"]
 
 
-# FIXME: replace this with an import from kornia.augmentation.utils when
-#  https://github.com/kornia/kornia/pull/677 is included in a release
-def _adapted_uniform(
-    shape: Union[Tuple, torch.Size],
-    low: Union[float, torch.Tensor],
-    high: Union[float, torch.Tensor],
-    same_on_batch: bool = False,
-) -> torch.Tensor:
-    if not isinstance(low, torch.Tensor):
-        low = torch.tensor(low).float()
-    if not isinstance(high, torch.Tensor):
-        high = torch.tensor(high).float()
-    dist = distributions.Uniform(low, high)
-    if same_on_batch:
-        samples = dist.rsample((1, *shape[1:])).repeat(
-            shape[0], *[1] * (len(shape) - 1)
-        )
-    else:
-        samples = dist.rsample(shape)
-    return cast(torch.Tensor, samples)
-
-
-class AugmentationBase(pystiche.ComplexObject, kornia.augmentation.AugmentationBase):
+class AugmentationBase2d(
+    pystiche.ComplexObject, kornia.augmentation.AugmentationBase2D
+):
     def _properties(self) -> Dict[str, Any]:
         dct = super()._properties()
+        dct["p"] = self.p
         if self.return_transform:
             dct["return_transform"] = True
         return dct
 
 
-class RandomRescale(AugmentationBase):
+def generate_vertices_from_size(batch_size: int, size: Tuple[int, int]) -> torch.Tensor:
+    height, width = size
+    return (
+        torch.tensor(
+            ((0, 0), (width - 1, 0), (width - 1, height - 1), (0, height - 1),),
+            dtype=torch.float,
+        )
+        .unsqueeze(0)
+        .repeat(batch_size, 1, 1)
+    )
+
+
+class RandomRescale(AugmentationBase2d):
     # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L63-L67
     # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L105-L114
     def __init__(
         self,
         factor: Union[Tuple[float, float], float],
-        probability: float = 50e-2,
+        p: float = 50e-2,
         interpolation: str = "bilinear",
         align_corners: bool = False,
     ):
-        super().__init__(return_transform=False)
+        super().__init__(p=p, return_transform=False)
         # Due to a bug in the implementation (low == high) the factor has not to be
         # chosen randomly
         # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L65-L66
         self.factor = to_2d_arg(factor)
-        self.probability = probability
         self.interpolation = interpolation
         self.align_corners = align_corners
         self.same_on_batch = True
 
-    def generate_parameters(self, input_shape: torch.Size) -> Dict[str, torch.Tensor]:
-        return cast(
-            Dict[str, torch.Tensor],
-            random_prob_generator(1, self.probability, self.same_on_batch),
+    def generate_parameters(self, batch_shape: torch.Size) -> Dict[str, torch.Tensor]:
+        batch_size, _, height, width = batch_shape
+        vert_factor, horz_factor = self.factor
+
+        start_points = generate_vertices_from_size(batch_size, (height, width))
+        end_points = generate_vertices_from_size(
+            batch_size, (int(height * vert_factor), int(width * horz_factor))
         )
+        return dict(start_points=start_points, end_points=end_points,)
+
+    def compute_transformation(
+        self, input: torch.Tensor, params: Dict[str, torch.Tensor]
+    ) -> torch.Tensor:
+        return F.compute_perspective_transformation(input, params)
 
     def apply_transform(
         self, input: torch.Tensor, params: Dict[str, torch.Tensor]
     ) -> torch.Tensor:
-        if not params["batch_prob"].item():
-            return input
-
-        height, width = extract_image_size(input)
-        factor_vert, factor_horz = self.factor
-        size = (int(height * factor_vert), int(width * factor_horz))
-        return cast(
-            torch.Tensor,
-            kornia.resize(
-                input,
-                size,
-                interpolation=self.interpolation,
-                align_corners=self.align_corners,
-            ),
+        transform = self.compute_transformation(input, params)
+        vertex = params["end_points"][0, 2, :]
+        size = tuple((vertex + 1).int().tolist()[::-1])
+        return warp_perspective(
+            input,
+            transform,
+            size,
+            flags=self.interpolation,
+            align_corners=self.align_corners,
         )
 
     def _properties(self) -> Dict[str, Any]:
         dct = super()._properties()
         dct["factor"] = self.factor
-        dct["probability"] = f"{self.probability:.1%}"
-        if self.interpolation != "bilinear":
-            dct["interpolation"] = self.interpolation
-        if self.same_on_batch:
-            dct["same_on_batch"] = True
-        if self.align_corners:
-            dct["align_corners"] = True
-        return dct
-
-
-class RandomRotation(pystiche.ComplexObject, kornia.augmentation.RandomRotation):
-    # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L72-L76
-    # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L116-L127
-    def __init__(
-        self,
-        degrees: Union[torch.Tensor, float, Tuple[float, float], List[float]],
-        probability: float = 50e-2,
-        interpolation: str = "bilinear",
-        **kwargs: Any,
-    ) -> None:
-        super().__init__(degrees, interpolation=interpolation, **kwargs)
-        self.probability = probability
-
-    def generate_parameters(self, batch_shape: torch.Size) -> Dict[str, torch.Tensor]:
-        batch_params = cast(
-            Dict[str, torch.Tensor],
-            random_prob_generator(batch_shape[0], self.probability, self.same_on_batch),
-        )
-        params = cast(Dict[str, torch.Tensor], super().generate_parameters(batch_shape))
-        params["degrees"][~batch_params["batch_prob"]] = 0.0
-        return params
-
-    def _properties(self) -> Dict[str, Any]:
-        dct = super()._properties()
-        dct["degrees"] = self.degrees
-        dct["probability"] = f"{self.probability:.1%}"
         if self.interpolation != "bilinear":
             dct["interpolation"] = self.interpolation
         if self.same_on_batch:
@@ -147,38 +109,29 @@ def affine_matrix_from_three_points(
     return torch.bmm(mat1, mat2)
 
 
-class RandomAffine(AugmentationBase):
+class RandomAffine(AugmentationBase2d):
     # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L78-L81
     # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L170-L180
     def __init__(
         self,
         shift: float,
-        probability: float = 50e-2,
+        p: float = 50e-2,
         interpolation: str = "bilinear",
         same_on_batch: bool = False,
         align_corners: bool = False,
     ):
-        super().__init__(return_transform=False)
+        super().__init__(p=p, return_transform=False)
         self.shift = shift
-        self.probability = probability
         self.interpolation = interpolation
         self.same_on_batch = same_on_batch
         self.align_corners = align_corners
 
     def generate_parameters(self, input_shape: torch.Size) -> Dict[str, torch.Tensor]:
-        batch_size = input_shape[0]
-        batch_params = cast(
-            Dict[str, torch.Tensor],
-            random_prob_generator(batch_size, self.probability, self.same_on_batch),
-        )
-
-        points = torch.tensor((((0, 0, 1), (0, 1, 0)),), dtype=torch.float).repeat(
-            batch_size, 1, 1
-        )
+        points = torch.tensor((((0, 0, 1), (0, 1, 0)),), dtype=torch.float)
+        points = points.repeat(input_shape[0], 1, 1)
         shift = _adapted_uniform(
             points.size(), -self.shift, self.shift, same_on_batch=self.same_on_batch
         )
-        shift[~batch_params["batch_prob"], ...] = 0.0
 
         return {"matrix": affine_matrix_from_three_points(points, points + shift)}
 
@@ -199,7 +152,6 @@ class RandomAffine(AugmentationBase):
     def _properties(self) -> Dict[str, Any]:
         dct = super()._properties()
         dct["shift"] = self.shift
-        dct["probability"] = f"{self.probability:.1%}"
         if self.interpolation != "bilinear":
             dct["interpolation"] = self.interpolation
         if self.same_on_batch:
@@ -269,13 +221,13 @@ def apply_hsv_jitter(
         99e-2 * 2.0 * kornia.pi,
     )
     s = torch.clamp(
-        h * params["saturation_scale"] + params["saturation_shift"], 1e-2, 99e-2,
+        s * params["saturation_scale"] + params["saturation_shift"], 1e-2, 99e-2
     )
-    v = torch.clamp(h * params["value_scale"] + params["value_shift"], 1e-2, 99e-2,)
+    v = torch.clamp(v * params["value_scale"] + params["value_shift"], 1e-2, 99e-2)
     return cast(torch.Tensor, kornia.hsv_to_rgb(torch.cat((h, s, v), dim=1)))
 
 
-class RandomHSVJitter(AugmentationBase):
+class RandomHSVJitter(AugmentationBase2d):
     # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L89-L95
     # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L141-L167
     def __init__(
@@ -286,9 +238,10 @@ class RandomHSVJitter(AugmentationBase):
         saturation_shift: Range,
         value_scale: Range,
         value_shift: Range,
+        p=0.5,
         same_on_batch: bool = False,
     ):
-        super().__init__(return_transform=False)
+        super().__init__(p=p, return_transform=False)
         self.hue_scale = hue_scale
         self.hue_shift = hue_shift
         self.saturation_scale = saturation_scale
@@ -370,25 +323,25 @@ class DynamicSizePad2d(pystiche.Module):
 
 
 def pre_crop_augmentation(
-    probability: float = 50e-2, same_on_batch: bool = True,
+    p: float = 50e-2, same_on_batch: bool = True,
 ) -> nn.Sequential:
     return nn.Sequential(
         # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L27
-        RandomRescale(factor=80e-2, probability=probability, interpolation="bicubic"),
+        # The interpolation mode should be "bicubic", but this isn't supported
+        # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L113
+        RandomRescale(factor=80e-2, p=p, interpolation="bilinear"),
         # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L71
         # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L82
         DynamicSizePad2d(
             nn.Sequential(
                 # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L28
-                RandomRotation(
-                    degrees=0.15 * 90,
-                    probability=probability,
-                    same_on_batch=same_on_batch,
+                # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L72-L76
+                # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L116-L127
+                augmentation.RandomRotation(
+                    degrees=0.15 * 90, p=p, same_on_batch=same_on_batch,
                 ),
                 # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L33
-                RandomAffine(
-                    5e-2, probability=probability, same_on_batch=same_on_batch
-                ),
+                RandomAffine(shift=5e-2, p=p, same_on_batch=same_on_batch),
             ),
             factor=50e-2,
             mode="reflect",
@@ -397,13 +350,11 @@ def pre_crop_augmentation(
 
 
 def post_crop_augmentation(
-    probability: float = 50e-2, same_on_batch: bool = True
+    p: float = 50e-2, same_on_batch: bool = True
 ) -> nn.Sequential:
     return nn.Sequential(
-        # The HSV jitter is used with a probability of 100%
-        # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/model.py#L273
         # Hue scaling is not implemented and thus we set it to 0
-        # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/model.py#L274-L276
+        # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/model.py#L273-L276
         RandomHSVJitter(
             hue_scale=0e-2,
             hue_shift=5e-2,
@@ -411,12 +362,11 @@ def post_crop_augmentation(
             saturation_shift=5e-2,
             value_scale=5e-2,
             value_shift=5e-2,
+            p=100e-2,
             same_on_batch=same_on_batch,
         ),
         # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L34
-        kornia.augmentation.RandomHorizontalFlip(
-            p=probability, same_on_batch=same_on_batch
-        ),
+        augmentation.RandomHorizontalFlip(p=p, same_on_batch=same_on_batch),
         # The vertical flip is used with a probability of 0% and thus left out
         # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/model.py#L272
     )

--- a/pystiche_papers/sanakoyeu_et_al_2018/_data.py
+++ b/pystiche_papers/sanakoyeu_et_al_2018/_data.py
@@ -140,7 +140,7 @@ class RandomCrop(AugmentationBase2d):
     def __init__(
         self,
         size: Union[Tuple[int, int], int],
-        p=0.5,
+        p: float = 0.5,
         interpolation: str = "bilinear",
         return_transform: bool = False,
         same_on_batch: bool = False,
@@ -152,7 +152,7 @@ class RandomCrop(AugmentationBase2d):
         self.same_on_batch = same_on_batch
         self.align_corners = align_corners
         self._flags = dict(
-            interpolation=torch.tensor(kornia.Resample.get(interpolation).value),
+            interpolation=torch.tensor(kornia.Resample.get(interpolation).value),  # type: ignore[attr-defined]
             align_corners=torch.tensor(align_corners),
         )
 
@@ -210,7 +210,7 @@ class RandomCrop(AugmentationBase2d):
     def apply_transform(
         self, input: torch.Tensor, params: Dict[str, torch.Tensor]
     ) -> torch.Tensor:
-        return cast(torch.Tensor, apply_crop(input, params, self._flags))
+        return apply_crop(input, params, self._flags)
 
     def _properties(self) -> Dict[str, Any]:
         dct = super()._properties()

--- a/pystiche_papers/sanakoyeu_et_al_2018/_data.py
+++ b/pystiche_papers/sanakoyeu_et_al_2018/_data.py
@@ -1,6 +1,9 @@
 from os import path
 from typing import Any, Dict, List, Optional, Sized, Tuple, Union, cast
 
+import kornia
+from kornia.augmentation.functional import apply_crop, compute_crop_transformation
+
 import torch
 from torch import nn
 from torch.utils.data import DataLoader, Dataset, Sampler
@@ -10,16 +13,21 @@ from torchvision.datasets.utils import download_and_extract_archive
 from pystiche.data import ImageFolderDataset
 from pystiche.image import transforms
 from pystiche.image.transforms import functional as F
-from pystiche.image.utils import extract_image_size
-from pystiche.misc import verify_str_arg
+from pystiche.image.utils import extract_edge_size, extract_image_size
+from pystiche.misc import to_2d_arg, verify_str_arg
 
-from ..utils import OptionalGrayscaleToFakegrayscale
-from ._augmentation import augmentation
+from ._augmentation import (
+    AugmentationBase,
+    _adapted_uniform,
+    post_crop_augmentation,
+    pre_crop_augmentation,
+)
 
 __all__ = [
     "ClampSize",
-    "style_image_transform",
-    "content_image_transform",
+    "OptionalUpsample",
+    "RandomCrop",
+    "image_transform",
     "WikiArt",
     "style_dataset",
     "content_dataset",
@@ -85,27 +93,169 @@ class ClampSize(transforms.Transform):
         return dct
 
 
-def style_image_transform(
-    impl_params: bool = True,
-    image_size: Tuple[int, int] = (768, 768),
-    train: bool = False,
+class OptionalUpsample(transforms.Transform):
+    def __init__(
+        self, min_edge_size: int, interpolation_mode: str = "bilinear"
+    ) -> None:
+        super().__init__()
+        self.min_edge_size = min_edge_size
+        self.interpolation_mode = interpolation_mode
+
+    def forward(self, image: torch.Tensor) -> torch.Tensor:
+        edge_size = extract_edge_size(image, edge="short")
+        if edge_size >= self.min_edge_size:
+            return image
+
+        return cast(
+            torch.Tensor,
+            F.resize(
+                image,
+                self.min_edge_size,
+                edge="short",
+                interpolation_mode=self.interpolation_mode,
+            ),
+        )
+
+    def _properties(self) -> Dict[str, Any]:
+        dct = super()._properties()
+        dct["min_edge_size"] = self.min_edge_size
+        if self.interpolation_mode != "bilinear":
+            dct["interpolation_mode"] = self.interpolation_mode
+        return dct
+
+
+def _adapted_uniform_int(
+    shape: Union[Tuple, torch.Size],
+    low: Union[float, torch.Tensor],
+    high: Union[float, torch.Tensor],
+    same_on_batch: bool = False,
+) -> torch.Tensor:
+    return _adapted_uniform(shape, low, high + 1 - 1e-6, same_on_batch).int()
+
+
+class RandomCrop(AugmentationBase):
+    # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L85-L87
+    # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L129-L139
+    def __init__(
+        self,
+        size: Union[Tuple[int, int], int],
+        interpolation: str = "bilinear",
+        return_transform: bool = False,
+        same_on_batch: bool = False,
+        align_corners: bool = False,
+    ) -> None:
+        super().__init__(return_transform=return_transform)
+        self.size = cast(Tuple[int, int], to_2d_arg(size))
+        self.interpolation = interpolation
+        self.same_on_batch = same_on_batch
+        self.align_corners = align_corners
+
+    def generate_parameters(self, input_shape: torch.Size) -> Dict[str, torch.Tensor]:
+        batch_size = input_shape[0]
+        image_size = cast(Tuple[int, int], input_shape[-2:])
+        anchors = self.generate_anchors(
+            batch_size, image_size, self.size, self.same_on_batch
+        )
+        dst = self.generate_vertices_from_size(batch_size, self.size)
+        src = self.clamp_vertices_to_size(anchors + dst, image_size)
+        return dict(
+            src=src,
+            dst=dst,
+            interpolation=torch.tensor(kornia.Resample.get(self.interpolation).value),
+            align_corners=torch.tensor(self.align_corners),
+        )
+
+    @staticmethod
+    def generate_anchors(
+        batch_size: int,
+        image_size: Tuple[int, int],
+        crop_size: Tuple[int, int],
+        same_on_batch: bool,
+    ) -> torch.Tensor:
+        def generate_single_dim_anchor(
+            batch_size: int, image_length: int, crop_length: int, same_on_batch: bool
+        ) -> torch.Tensor:
+            diff = image_length - crop_length
+            if diff <= 0:
+                return torch.zeros((batch_size,), dtype=torch.int)
+            else:
+                return _adapted_uniform_int((batch_size,), 0, diff, same_on_batch)
+
+        single_dim_anchors = [
+            generate_single_dim_anchor(
+                batch_size, image_length, crop_length, same_on_batch
+            )
+            for image_length, crop_length in zip(image_size, crop_size)
+        ]
+        return torch.stack(single_dim_anchors, dim=1,).unsqueeze(1).repeat(1, 4, 1)
+
+    @staticmethod
+    def generate_vertices_from_size(
+        batch_size: int, size: Tuple[int, int]
+    ) -> torch.Tensor:
+        height, width = size
+        return (
+            torch.tensor(
+                ((0, 0), (width - 1, 0), (width - 1, height - 1), (0, height - 1),),
+                dtype=torch.int,
+            )
+            .unsqueeze(0)
+            .repeat(batch_size, 1, 1)
+        )
+
+    @staticmethod
+    def clamp_vertices_to_size(
+        vertices: torch.Tensor, size: Tuple[int, int]
+    ) -> torch.Tensor:
+        horz, vert = vertices.split(1, dim=2)
+        height, width = size
+        return torch.cat(
+            (torch.clamp(horz, 0, width - 1), torch.clamp(vert, 0, height - 1),), dim=2,
+        )
+
+    def compute_transformation(
+        self, input: torch.Tensor, params: Dict[str, torch.Tensor]
+    ) -> torch.Tensor:
+        return cast(torch.Tensor, compute_crop_transformation(input, params))
+
+    def apply_transform(
+        self, input: torch.Tensor, params: Dict[str, torch.Tensor]
+    ) -> torch.Tensor:
+        return cast(torch.Tensor, apply_crop(input, params))
+
+    def _properties(self) -> Dict[str, Any]:
+        dct = super()._properties()
+        dct["size"] = self.size
+        if self.interpolation != "bilinear":
+            dct["interpolation"] = self.interpolation
+        if self.same_on_batch:
+            dct["same_on_batch"] = True
+        if self.align_corners:
+            dct["align_corners"] = True
+        return dct
+
+
+def image_transform(
+    impl_params: bool = True, edge_size: int = 768, train: bool = False
 ) -> nn.Sequential:
     transforms_: List[nn.Module] = [
-        ClampSize(),
-        transforms.ValidRandomCrop(image_size),
-        OptionalGrayscaleToFakegrayscale(),
+        ClampSize() if impl_params else OptionalUpsample(edge_size),
     ]
-    if impl_params and train:
-        transforms_.append(augmentation(image_size=image_size))
+    # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/model.py#L286-L287
+    # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/model.py#L291-L292
+    # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/model.py#L271-L276
+    # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/img_augm.py#L24
+    augmentation = impl_params and train
+    if augmentation:
+        transforms_.append(pre_crop_augmentation())
+    transforms_.append(
+        RandomCrop(edge_size)  # type: ignore[arg-type]
+        if impl_params
+        else transforms.ValidRandomCrop(edge_size)
+    )
+    if augmentation:
+        transforms_.append(post_crop_augmentation())
     return nn.Sequential(*transforms_)
-
-
-def content_image_transform(impl_params: bool = True, **kwargs: Any) -> nn.Sequential:
-    transform = style_image_transform(impl_params=impl_params, **kwargs)
-    if not impl_params:
-        return transform
-
-    return nn.Sequential(transforms.Rescale(2.0), transform)
 
 
 class WikiArt(ImageFolderDataset):
@@ -178,11 +328,12 @@ class WikiArt(ImageFolderDataset):
 def style_dataset(
     root: str,
     style: str,
+    impl_params: bool = True,
     transform: Optional[nn.Module] = None,
     download: bool = False,
 ) -> WikiArt:
     if transform is None:
-        transform = style_image_transform()
+        transform = image_transform(impl_params=impl_params)
     return WikiArt(root, style, transform=transform, download=download)
 
 
@@ -192,7 +343,10 @@ def content_dataset(
     root: str, impl_params: bool = True, transform: Optional[nn.Module] = None,
 ) -> ImageFolderDataset:
     if transform is None:
-        transform = content_image_transform(impl_params=impl_params)
+        transform = image_transform(impl_params=impl_params)
+        # https://github.com/pmeier/adaptive-style-transfer/blob/07a3b3fcb2eeed2bf9a22a9de59c0aea7de44181/prepare_dataset.py#L133
+        if impl_params:
+            transform = nn.Sequential(transforms.Rescale(2.0), transform)
     return ImageFolderDataset(root, transform=transform)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     pystiche >= 0.6
     torch >= 1.6
     torchvision >= 0.7
-    kornia >= 0.4
+    kornia == 0.4.1
     more_itertools >= 2.5
 
 [options.packages.find]

--- a/tests/download/paper/test_sanakoyeu_et_al_2018.py
+++ b/tests/download/paper/test_sanakoyeu_et_al_2018.py
@@ -2,7 +2,7 @@ import pytest
 
 import pystiche_papers.sanakoyeu_et_al_2018 as paper
 
-from ..asserts import assert_is_downloadable
+from ..utils import assert_is_downloadable
 
 
 @pytest.mark.slow

--- a/tests/parametrize.py
+++ b/tests/parametrize.py
@@ -1,0 +1,26 @@
+import pytest
+
+__all__ = ["data", "impl_params"]
+
+
+def data(argnames, argvalues, ids=None, **kwargs):
+    if isinstance(argnames, str):
+        argnames = [name.strip() for name in argnames.split(",")]
+
+    single_arg = len(argnames) == 1
+
+    if ids is None:
+        if single_arg:
+            ids = [f"{argnames[0]}={value}" for value in argvalues]
+        else:
+            ids = [
+                ", ".join(f"{name}={value}" for name, value in zip(argnames, values))
+                for values in argvalues
+            ]
+
+    return pytest.mark.parametrize(
+        argnames[0] if single_arg else argnames, argvalues, ids=ids, **kwargs
+    )
+
+
+impl_params = data("impl_params", (True, False))

--- a/tests/unit/sanakoyeu_et_al_2018/test_augmentation.py
+++ b/tests/unit/sanakoyeu_et_al_2018/test_augmentation.py
@@ -54,7 +54,7 @@ def make_reproducible():
 
 def test_RandomRescale(input_image):
     factor = 0.5
-    transform = RandomRescale(factor, probability=100e-2)
+    transform = RandomRescale(factor, p=100e-2)
 
     actual = transform(input_image)
     expected = rescale(input_image, factor)
@@ -64,7 +64,7 @@ def test_RandomRescale(input_image):
 def test_RandomRescale_noop(subtests, input_image):
     for factor, probability in ((1.0, 100e-2), (0.5, 0e-2)):
         with subtests.test(factor=factor, probability=probability):
-            transform = RandomRescale(factor, probability=probability)
+            transform = RandomRescale(factor, p=probability)
             assert_is_noop(input_image, transform)
 
 
@@ -83,14 +83,14 @@ def test_RandomRotation_noop(subtests, input_image):
 
 def test_RandomAffine_smoke(input_image):
     shift = 0.2
-    transform = RandomAffine(shift, probability=100e-2)
+    transform = RandomAffine(shift, p=100e-2)
     assert_is_size_and_value_range_preserving(input_image, transform)
 
 
 def test_RandomAffine_noop(subtests, input_image):
     for shift, probability in ((0.0, 100e-2), (0.2, 0e-2)):
         with subtests.test(degrees=shift, probability=probability):
-            transform = RandomAffine(shift, probability=probability)
+            transform = RandomAffine(shift, p=probability)
             assert_is_noop(input_image, transform)
 
 
@@ -119,9 +119,7 @@ def test_pre_crop_augmentation_smoke(subtests, input_image):
     same_on_batch = True
 
     input_image = utils.batch_up_image(input_image, 2)
-    transform = paper.pre_crop_augmentation(
-        probability=probability, same_on_batch=same_on_batch
-    )
+    transform = paper.pre_crop_augmentation(p=probability, same_on_batch=same_on_batch)
 
     output_image = transform(input_image)
 
@@ -148,9 +146,7 @@ def test_post_crop_augmentation_smoke(subtests, input_image):
     same_on_batch = True
 
     input_image = utils.batch_up_image(input_image, 2)
-    transform = paper.post_crop_augmentation(
-        probability=probability, same_on_batch=same_on_batch
-    )
+    transform = paper.post_crop_augmentation(p=probability, same_on_batch=same_on_batch)
 
     output_image = assert_is_size_and_value_range_preserving(input_image, transform)
 


### PR DESCRIPTION
This fixes multiple issues with respect to the image transformations and augmentation:

- Currently, the augmentation defines a separate transform including a random crop after the image transform (`resize -> crop -> augmentation`). Thus, the random crop is performed twice. This PR splits the augmentation in two parts to account for that (`resize -> pre-crop augmentation -> crop -> post-crop-augmentation`)
- Currently, the content image transform includes an prefixed upscaling of factor 2. This is better placed at the content dataset.
