### PR TITLE
fix li_wand_2016 target_transforms

### DIFF
--- a/docs/source/api/pystiche_papers.li_wand_2016.rst
+++ b/docs/source/api/pystiche_papers.li_wand_2016.rst
@@ -35,7 +35,8 @@ parts are affected:
   - :func:`~pystiche_papers.li_wand_2016.image_pyramid`,
   - :func:`~pystiche_papers.li_wand_2016.content_loss`,
   - :func:`~pystiche_papers.li_wand_2016.style_loss`,
-  - :func:`~pystiche_papers.li_wand_2016.regularization`.
+  - :func:`~pystiche_papers.li_wand_2016.regularization`,
+  - :func:`~pystiche_papers.li_wand_2016.target_transforms`.
 
 
 .. automodule:: pystiche_papers.li_wand_2016
@@ -52,3 +53,4 @@ parts are affected:
 .. autofunction:: postprocessor
 .. autofunction:: regularization
 .. autofunction:: style_loss
+.. autofunction:: target_transforms

--- a/pystiche_papers/li_wand_2016/_loss.py
+++ b/pystiche_papers/li_wand_2016/_loss.py
@@ -191,6 +191,7 @@ def style_loss(
         num_rotate_steps = 0 if impl_params else 2
         rotate_step_width = 7.5
         target_transforms = _target_transforms(
+            impl_params=impl_params,
             num_scale_steps=num_scale_steps,
             scale_step_width=scale_step_width,
             num_rotate_steps=num_rotate_steps,

--- a/pystiche_papers/li_wand_2016/_loss.py
+++ b/pystiche_papers/li_wand_2016/_loss.py
@@ -10,6 +10,7 @@ from pystiche.image import transforms
 
 from ._utils import extract_normalized_patches2d
 from ._utils import multi_layer_encoder as _multi_layer_encoder
+from ._utils import target_transforms as _target_transforms
 
 __all__ = [
     "FeatureReconstructionOperator",
@@ -91,7 +92,6 @@ class MRFOperator(ops.MRFOperator):
         impl_params: bool = True,
         **mrf_op_kwargs: Any,
     ):
-
         super().__init__(encoder, patch_size, **mrf_op_kwargs)
 
         # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/mylib/mrf.lua#L108
@@ -190,7 +190,7 @@ def style_loss(
         # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/cnnmrf.lua#L51
         num_rotate_steps = 0 if impl_params else 2
         rotate_step_width = 7.5
-        target_transforms = MRFOperator.scale_and_rotate_transforms(
+        target_transforms = _target_transforms(
             num_scale_steps=num_scale_steps,
             scale_step_width=scale_step_width,
             num_rotate_steps=num_rotate_steps,

--- a/pystiche_papers/li_wand_2016/_utils.py
+++ b/pystiche_papers/li_wand_2016/_utils.py
@@ -256,14 +256,13 @@ def target_transforms(
             implementation of the original authors rather than what is described in
             the paper. For details see below.
         num_scale_steps: Number of scale steps. Each scale is performed in both
-            directions, i.e. enlarging and shrinking the motif. Defaults to ``1``.
-        scale_step_width: Width of each scale step. Defaults to ``0`` if
+            directions, i.e. enlarging and shrinking the motif. Defaults to ``0`` if
             ``impl_params is True`` otherwise ``3``.
+        scale_step_width: Width of each scale step. Defaults to ``5e-2``.
         num_rotate_steps: Number of rotate steps. Each rotate is performed in both
             directions, i.e. clockwise and counterclockwise. Defaults to ``0`` if
             ``impl_params is True`` otherwise ``2``.
-        rotate_step_width: Width of each rotation step in degrees.
-            Defaults to ``7.5``.
+        rotate_step_width: Width of each rotation step in degrees. Defaults to ``7.5``.
 
     Returns:
        ``(num_scale_steps * 2 + 1) * (num_rotate_steps * 2 + 1)`` transformations

--- a/pystiche_papers/li_wand_2016/_utils.py
+++ b/pystiche_papers/li_wand_2016/_utils.py
@@ -1,14 +1,18 @@
-from typing import Any, Sequence, Tuple, Union
+import itertools
+import math
+from typing import Any, Dict, Optional, Sequence, Tuple, Union, cast
 
 import torch
 from torch import optim
 
 import pystiche
-from pystiche import enc, misc
-from pystiche.image import transforms
+from pystiche import enc, misc, ops
+from pystiche.image import extract_image_size, transforms
+from pystiche.image.transforms.functional import crop
 
 __all__ = [
     "extract_normalized_patches2d",
+    "target_transforms",
     "preprocessor",
     "postprocessor",
     "multi_layer_encoder",
@@ -109,6 +113,178 @@ def extract_normalized_patches2d(
     for dim, size, step in zip(range(2, input.dim()), patch_size, stride):
         input = normalize_unfold_grad(input, dim, size, step)
     return pystiche.extract_patches2d(input, patch_size, stride)
+
+
+# Right now, this an (almost) exact port from the source. It needs to be refactored.
+# It does the following for a positive alpha (angle):
+# - create the vertices of the image
+# - rotate these vertices clockwise (!)
+# - find the intersection of the old vertical left edge with the new "horizontal"
+#   bottom edge
+# - find the intersection of the old vertical right with the horizontal extension of
+#   the first intersection
+# - Use the second intersection as bottom right vertex
+# - Use the the difference of image size and bottom right corner as top left vertex
+# https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/mylib/helper.lua#L74-L139
+def _computeBB(width: int, height: int, alpha: float) -> Tuple[int, int, int, int]:
+    x1 = 1
+    y1 = 1
+    x2 = width
+    y2 = 1
+    x3 = width
+    y3 = height
+    x4 = 1
+    y4 = height
+    x0 = width / 2
+    y0 = height / 2
+
+    x1r = x0 + (x1 - x0) * math.cos(alpha) + (y1 - y0) * math.sin(alpha)
+    y1r = y0 - (x1 - x0) * math.sin(alpha) + (y1 - y0) * math.cos(alpha)
+
+    x2r = x0 + (x2 - x0) * math.cos(alpha) + (y2 - y0) * math.sin(alpha)
+    y2r = y0 - (x2 - x0) * math.sin(alpha) + (y2 - y0) * math.cos(alpha)
+
+    x3r = x0 + (x3 - x0) * math.cos(alpha) + (y3 - y0) * math.sin(alpha)
+    y3r = y0 - (x3 - x0) * math.sin(alpha) + (y3 - y0) * math.cos(alpha)
+
+    x4r = x0 + (x4 - x0) * math.cos(alpha) + (y4 - y0) * math.sin(alpha)
+    y4r = y0 - (x4 - x0) * math.sin(alpha) + (y4 - y0) * math.cos(alpha)
+
+    if alpha > 0:
+        px1 = (
+            (x1 * y4 - y1 * x4) * (x1r - x2r) - (x1 - x4) * (x1r * y2r - y1r * x2r)
+        ) / ((x1 - x4) * (y1r - y2r) - (y1 - y4) * (x1r - x2r))
+        py1 = (
+            (x1 * y4 - y1 * x4) * (y1r - y2r) - (y1 - y4) * (x1r * y2r - y1r * x2r)
+        ) / ((x1 - x4) * (y1r - y2r) - (y1 - y4) * (x1r - x2r))
+        px2 = px1 + 1
+        py2 = py1
+
+        qx = (
+            (px1 * py2 - py1 * px2) * (x2r - x3r)
+            - (px1 - px2) * (x2r * y3r - y2r * x3r)
+        ) / ((px1 - px2) * (y2r - y3r) - (py1 - py2) * (x2r - x3r))
+        qy = (
+            (px1 * py2 - py1 * px2) * (y2r - y3r)
+            - (py1 - py2) * (x2r * y3r - y2r * x3r)
+        ) / ((px1 - px2) * (y2r - y3r) - (py1 - py2) * (x2r - x3r))
+
+        min_x = width - qx
+        min_y = qy
+        max_x = qx
+        max_y = height - qy
+
+    elif alpha < 0:
+        px1 = (
+            (x2 * y3 - y2 * x3) * (x1r - x2r) - (x2 - x3) * (x1r * y2r - y1r * x2r)
+        ) / ((x2 - x3) * (y1r - y2r) - (y2 - y3) * (x1r - x2r))
+        py1 = (
+            (x2 * y3 - y1 * x3) * (y1r - y2r) - (y2 - y3) * (x1r * y2r - y1r * x2r)
+        ) / ((x2 - x3) * (y1r - y2r) - (y2 - y3) * (x1r - x2r))
+        px2 = px1 - 1
+        py2 = py1
+
+        qx = (
+            (px1 * py2 - py1 * px2) * (x1r - x4r)
+            - (px1 - px2) * (x1r * y4r - y1r * x4r)
+        ) / ((px1 - px2) * (y1r - y4r) - (py1 - py2) * (x1r - x4r))
+        qy = (
+            (px1 * py2 - py1 * px2) * (y1r - y4r)
+            - (py1 - py2) * (x1r * y4r - y1r * x4r)
+        ) / ((px1 - px2) * (y1r - y4r) - (py1 - py2) * (x1r - x4r))
+        min_x = qx
+        min_y = qy
+        max_x = width - min_x
+        max_y = height - min_y
+    else:
+        min_x = x1
+        min_y = y1
+        max_x = x2
+        max_y = y3
+
+    return (
+        max(math.floor(min_x), 1),
+        max(math.floor(min_y), 1),
+        # The clamping to the maximum height and width is not part of the original
+        # implementation.
+        min(math.floor(max_x), width),
+        min(math.floor(max_y), height),
+    )
+
+
+class ValidCropAfterRotate(transforms.Transform):
+    def __init__(self, angle: float, clockwise: bool = False):
+        super().__init__()
+        self.angle = angle
+        self.clockwise = clockwise
+
+    def forward(self, image: torch.Tensor) -> torch.Tensor:
+        origin, size = self._compute_crop(image)
+        return cast(torch.Tensor, crop(image, origin, size))
+
+    def _compute_crop(
+        self, image: torch.Tensor
+    ) -> Tuple[Tuple[int, int], Tuple[int, int]]:
+        height, width = extract_image_size(image)
+        alpha = math.radians(self.angle)
+        if not self.clockwise:
+            alpha *= -1
+        bounding_box = _computeBB(width, height, alpha)
+        origin = (bounding_box[1], bounding_box[0])
+        size = (bounding_box[3] - bounding_box[1], bounding_box[2] - bounding_box[0])
+        return origin, size
+
+    def _properties(self) -> Dict[str, Any]:
+        dct = super()._properties()
+        dct["angle"] = f"{self.angle}°"
+        if self.clockwise:
+            dct["clockwise"] = self.clockwise
+        return dct
+
+
+def target_transforms(
+    impl_params: bool = True,
+    num_scale_steps: Optional[int] = None,
+    scale_step_width: float = 5e-2,
+    num_rotate_steps: Optional[int] = None,
+    rotate_step_width: float = 7.5,
+) -> Sequence[transforms.Transform]:
+    if num_scale_steps is None:
+        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/cnnmrf.lua#L52
+        num_scale_steps = 0 if impl_params else 3
+    if num_rotate_steps is None:
+        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/cnnmrf.lua#L51
+        num_rotate_steps = 0 if impl_params else 2
+
+    if not impl_params:
+        return ops.MRFOperator.scale_and_rotate_transforms(
+            num_scale_steps=num_scale_steps,
+            scale_step_width=scale_step_width,
+            num_rotate_steps=num_rotate_steps,
+            rotate_step_width=rotate_step_width,
+        )
+
+    scaling_factors = [
+        1.0 + (base * scale_step_width)
+        for base in range(-num_scale_steps, num_scale_steps + 1)
+    ]
+    rotation_angles = [
+        base * rotate_step_width
+        for base in range(-num_rotate_steps, num_rotate_steps + 1)
+    ]
+
+    transforms_ = []
+    for scaling_factor, rotation_angle in itertools.product(
+        scaling_factors, rotation_angles
+    ):
+        transforms_.append(
+            transforms.ComposedTransform(
+                transforms.RotateMotif(rotation_angle),
+                ValidCropAfterRotate(rotation_angle),
+                transforms.Rescale(scaling_factor),
+            )
+        )
+    return transforms_
 
 
 def preprocessor() -> transforms.CaffePreprocessing:

--- a/pystiche_papers/li_wand_2016/_utils.py
+++ b/pystiche_papers/li_wand_2016/_utils.py
@@ -249,6 +249,33 @@ def target_transforms(
     num_rotate_steps: Optional[int] = None,
     rotate_step_width: float = 7.5,
 ) -> Sequence[transforms.Transform]:
+    r"""Generate a list of scaling and rotations transformations.
+
+    Args:
+        impl_params: If ``True``, uses the parameters used in the reference
+            implementation of the original authors rather than what is described in
+            the paper. For details see below.
+        num_scale_steps: Number of scale steps. Each scale is performed in both
+            directions, i.e. enlarging and shrinking the motif. Defaults to ``1``.
+        scale_step_width: Width of each scale step. Defaults to ``0`` if
+            ``impl_params is True`` otherwise ``3``.
+        num_rotate_steps: Number of rotate steps. Each rotate is performed in both
+            directions, i.e. clockwise and counterclockwise. Defaults to ``0`` if
+            ``impl_params is True`` otherwise ``2``.
+        rotate_step_width: Width of each rotation step in degrees.
+            Defaults to ``7.5``.
+
+    Returns:
+       ``(num_scale_steps * 2 + 1) * (num_rotate_steps * 2 + 1)`` transformations
+       in total comprising every combination given by the input parameters.
+
+    If ``impl_params is True``, every transformation comprises a valid crop after the
+    rotation to avoid blank regions. Furthermore, the image is actually rescaled
+    instead of the motif, resulting in more patches overall.
+
+    Otherwise, :meth:`pystiche.ops.MRFOperator.scale_and_rotate_transforms` is used to
+    generate the transforms.
+    """
     if num_scale_steps is None:
         # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/cnnmrf.lua#L52
         num_scale_steps = 0 if impl_params else 3

--- a/replication/li_wand_2016/main.py
+++ b/replication/li_wand_2016/main.py
@@ -28,7 +28,7 @@ def figure_6(args):
             f"Replicating the {position} half of figure 6 " f"with {params} parameters"
         )
 
-        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/run_trans.lua#L67
+        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/run_trans.lua#L66
         style_loss_kwargs = {
             "patch_size": 2,
             "stride": 1,

--- a/replication/li_wand_2016/main.py
+++ b/replication/li_wand_2016/main.py
@@ -5,7 +5,6 @@ from os import path
 import pystiche_papers.li_wand_2016 as paper
 from pystiche.image import write_image
 from pystiche.misc import get_device
-from pystiche.ops import MRFOperator
 from pystiche.optim import OptimLogger
 from pystiche_papers.utils import abort_if_cuda_memory_exausts
 
@@ -29,14 +28,13 @@ def figure_6(args):
             f"Replicating the {position} half of figure 6 " f"with {params} parameters"
         )
 
-        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/run_trans.lua#L65-L70
+        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/run_trans.lua#L67
         style_loss_kwargs = {
-            "target_transforms": MRFOperator.scale_and_rotate_transforms(
-                num_scale_steps=1,
-                scale_step_width=5e-2,
-                num_rotate_steps=1,
-                rotate_step_width=7.5,
-            )
+            "patch_size": 2,
+            "stride": 1,
+            "target_transforms": paper.target_transforms(
+                num_scale_steps=1, num_rotate_steps=1,
+            ),
         }
         criterion = paper.perceptual_loss(
             impl_params=args.impl_params, style_loss_kwargs=style_loss_kwargs

--- a/replication/li_wand_2016/main.py
+++ b/replication/li_wand_2016/main.py
@@ -29,13 +29,14 @@ def figure_6(args):
         )
 
         # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/run_trans.lua#L66
-        style_loss_kwargs = {
-            "patch_size": 2,
-            "stride": 1,
-            "target_transforms": paper.target_transforms(
-                num_scale_steps=1, num_rotate_steps=1,
+        target_transforms_kwargs = (
+            dict(num_scale_steps=1, num_rotate_steps=1) if args.impl_params else {}
+        )
+        style_loss_kwargs = dict(
+            target_transforms=paper.target_transforms(
+                impl_params=args.impl_params, **target_transforms_kwargs
             ),
-        }
+        )
         criterion = paper.perceptual_loss(
             impl_params=args.impl_params, style_loss_kwargs=style_loss_kwargs
         )

--- a/tests/unit/li_wand_2016/test_loss.py
+++ b/tests/unit/li_wand_2016/test_loss.py
@@ -8,6 +8,8 @@ import pystiche.ops.functional as F
 import pystiche_papers.li_wand_2016 as paper
 from pystiche import loss, misc, ops
 
+from tests import utils
+
 
 def test_FeatureReconstructionOperator(
     subtests, multi_layer_encoder_with_layer, target_image, input_image
@@ -107,31 +109,22 @@ def test_style_loss(subtests):
             assert layer_weights == (1.0,) * len(layers)
 
 
-def test_style_loss_pyramid(subtests, mocker):
-    configs = ((True, 0, 0), (False, 3, 2))
-    for impl_params, num_scale_steps, num_rotate_steps in configs:
-        mock = mocker.patch(
-            "pystiche.ops.comparison.MRFOperator.scale_and_rotate_transforms"
-        )
-        paper.style_loss(impl_params=impl_params)
+@utils.parametrize_data(
+    ("impl_params", "num_scale_steps", "num_rotate_steps"),
+    pytest.param(True, 0, 0),
+    pytest.param(False, 3, 2),
+)
+def test_style_loss_pyramid(mocker, impl_params, num_scale_steps, num_rotate_steps):
+    mock = mocker.patch("pystiche_papers.li_wand_2016._loss._target_transforms")
+    paper.style_loss(impl_params=impl_params)
 
-        _, kwargs = mock.call_args
-        pyramid_num_scale_steps = kwargs["num_scale_steps"]
-        pyramid_scale_step_width = kwargs["scale_step_width"]
-        pyramid_num_rotate_steps = kwargs["num_rotate_steps"]
-        pyramid_rotate_step_width = kwargs["rotate_step_width"]
+    args = utils.call_args_to_namespace(mock.call_args, paper.target_transforms)
 
-        with subtests.test("num_scale_steps"):
-            assert pyramid_num_scale_steps == num_scale_steps
-
-        with subtests.test("num_scale_steps"):
-            assert pyramid_scale_step_width == pytest.approx(5e-2)
-
-        with subtests.test("num_rotate_steps"):
-            assert pyramid_num_rotate_steps == num_rotate_steps
-
-        with subtests.test("rotate_step_width"):
-            assert pyramid_rotate_step_width == pytest.approx(7.5)
+    assert args.impl_params is impl_params
+    assert args.num_scale_steps == num_scale_steps
+    assert args.scale_step_width == pytest.approx(5e-2)
+    assert args.num_rotate_steps == num_rotate_steps
+    assert args.rotate_step_width == pytest.approx(7.5)
 
 
 def test_TotalVariationOperator(subtests, input_image):

--- a/tests/unit/li_wand_2016/test_loss.py
+++ b/tests/unit/li_wand_2016/test_loss.py
@@ -114,7 +114,9 @@ def test_style_loss(subtests):
     pytest.param(True, 0, 0),
     pytest.param(False, 3, 2),
 )
-def test_style_loss_pyramid(mocker, impl_params, num_scale_steps, num_rotate_steps):
+def test_style_loss_target_transforms(
+    mocker, impl_params, num_scale_steps, num_rotate_steps
+):
     mock = mocker.patch("pystiche_papers.li_wand_2016._loss._target_transforms")
     paper.style_loss(impl_params=impl_params)
 

--- a/tests/unit/li_wand_2016/test_utils.py
+++ b/tests/unit/li_wand_2016/test_utils.py
@@ -80,6 +80,19 @@ def test_extract_normalized_patches2d_no_overlap(subtests):
         ptu.assert_allclose(input_normalized.grad, input.grad)
 
 
+def test_target_transforms_smoke():
+    num_scale_steps = 2
+    num_rotate_steps = 3
+
+    target_transforms = paper.target_transforms(
+        num_scale_steps=num_scale_steps, num_rotate_steps=num_rotate_steps,
+    )
+
+    actual = len(target_transforms)
+    expected = (num_scale_steps * 2 + 1) * (num_rotate_steps * 2 + 1)
+    assert actual == expected
+
+
 def test_preprocessor():
     assert isinstance(paper.preprocessor(), transforms.CaffePreprocessing)
 

--- a/tests/unit/li_wand_2016/test_utils.py
+++ b/tests/unit/li_wand_2016/test_utils.py
@@ -90,6 +90,11 @@ def test_target_transforms_smoke(impl_params, num_transforms):
     assert len(target_transforms) == num_transforms
 
 
+def test_target_transform_smoke(target_image):
+    transform = paper.target_transforms(impl_params=True)[0]
+    assert isinstance(transform(target_image), torch.Tensor)
+
+
 def test_preprocessor():
     assert isinstance(paper.preprocessor(), transforms.CaffePreprocessing)
 

--- a/tests/unit/li_wand_2016/test_utils.py
+++ b/tests/unit/li_wand_2016/test_utils.py
@@ -9,6 +9,8 @@ import pystiche_papers.li_wand_2016 as paper
 from pystiche import enc
 from pystiche.image import transforms
 
+from tests import utils
+
 
 def test_extract_normalized_patches2d(subtests):
     height = 4
@@ -80,17 +82,12 @@ def test_extract_normalized_patches2d_no_overlap(subtests):
         ptu.assert_allclose(input_normalized.grad, input.grad)
 
 
-def test_target_transforms_smoke():
-    num_scale_steps = 2
-    num_rotate_steps = 3
-
-    target_transforms = paper.target_transforms(
-        num_scale_steps=num_scale_steps, num_rotate_steps=num_rotate_steps,
-    )
-
-    actual = len(target_transforms)
-    expected = (num_scale_steps * 2 + 1) * (num_rotate_steps * 2 + 1)
-    assert actual == expected
+@utils.parametrize_data(
+    ("impl_params", "num_transforms"), pytest.param(True, 1), pytest.param(False, 35),
+)
+def test_target_transforms_smoke(impl_params, num_transforms):
+    target_transforms = paper.target_transforms(impl_params=impl_params)
+    assert len(target_transforms) == num_transforms
 
 
 def test_preprocessor():

--- a/tests/unit/li_wand_2016/test_utils.py
+++ b/tests/unit/li_wand_2016/test_utils.py
@@ -90,9 +90,11 @@ def test_target_transforms_smoke(impl_params, num_transforms):
     assert len(target_transforms) == num_transforms
 
 
-def test_target_transform_smoke(target_image):
-    transform = paper.target_transforms(impl_params=True)[0]
-    assert isinstance(transform(target_image), torch.Tensor)
+def test_target_transforms_call_smoke(target_image):
+    for transform in paper.target_transforms(
+        impl_params=True, num_scale_steps=1, num_rotate_steps=1
+    ):
+        assert isinstance(transform(target_image), torch.Tensor)
 
 
 def test_preprocessor():


### PR DESCRIPTION
With `impl_params=True` we cannot use the default `pystiche.ops.MRFOperator.scale_and_rotate_transforms`, but need to use custom code instead. With this the replication now yields almost the same results as the reference implementation:

# Theirs

![res_3_100](https://user-images.githubusercontent.com/6849766/98857935-0f794c00-2460-11eb-93b1-9b303a6ae3cc.jpg)


# Our

![fig_6__top](https://user-images.githubusercontent.com/6849766/98857971-1bfda480-2460-11eb-955b-e382c27847d8.jpg)

Todo:

- [x] tests
- [x] documentation