### PR TITLE
Add content images from the repository

### DIFF
--- a/pystiche_papers/sanakoyeu_et_al_2018/_data.py
+++ b/pystiche_papers/sanakoyeu_et_al_2018/_data.py
@@ -2,6 +2,7 @@ import os
 import re
 from os import path
 from typing import Any, Dict, List, Optional, Sized, Tuple, Union, cast
+from urllib.parse import urljoin
 
 import kornia
 from kornia.augmentation.functional import apply_crop, compute_crop_transformation
@@ -12,7 +13,11 @@ from torch.utils.data import DataLoader, Dataset, Sampler
 from torch.utils.data.sampler import RandomSampler
 from torchvision.datasets.utils import download_and_extract_archive
 
-from pystiche.data import ImageFolderDataset
+from pystiche.data import (
+    DownloadableImage,
+    DownloadableImageCollection,
+    ImageFolderDataset,
+)
 from pystiche.image import transforms
 from pystiche.image.transforms import functional as F
 from pystiche.image.utils import extract_edge_size, extract_image_size
@@ -31,6 +36,7 @@ __all__ = [
     "OptionalUpsample",
     "RandomCrop",
     "image_transform",
+    "images",
     "WikiArt",
     "style_dataset",
     "Places365Subset",
@@ -245,6 +251,62 @@ def image_transform(impl_params: bool = True, edge_size: int = 768) -> nn.Sequen
     if impl_params:
         transforms_.append(post_crop_augmentation())
     return nn.Sequential(*transforms_)
+
+
+def images() -> DownloadableImageCollection:
+    base_sanakoyeu = "https://raw.githubusercontent.com/CompVis/adaptive-style-transfer/gh-pages/images/experiments/comparison_with_others/"
+    content_images = {
+        "garden": DownloadableImage(
+            urljoin(
+                urljoin(base_sanakoyeu, "0063/"), "Places365_val_00009975_content.jpg"
+            ),
+            md5="f08cfeef2e020555e6bcf0f15d9d0e36",
+        ),
+        "bridge_river": DownloadableImage(
+            urljoin(
+                urljoin(base_sanakoyeu, "0065/"), "Places365_val_00010170_content.jpg"
+            ),
+            md5="df290455d760e566b498878edb07e82c",
+        ),
+        "glacier_human": DownloadableImage(
+            urljoin(
+                urljoin(base_sanakoyeu, "0066/"), "Places365_val_00010262_content.jpg"
+            ),
+            md5="420b014fc6b2e059a7c421ee5409495e",
+        ),
+        "mountain": DownloadableImage(
+            urljoin(
+                urljoin(base_sanakoyeu, "0074/"), "Places365_val_00010926_content.jpg"
+            ),
+            md5="127ae1ad474a24a763d2f4f43b1c311e",
+        ),
+        "horses": DownloadableImage(
+            urljoin(
+                urljoin(base_sanakoyeu, "0076/"), "Places365_val_00010957_content.jpg"
+            ),
+            md5="99658ffb5cea1275cf2411ba431a5b3c",
+        ),
+        "stone_facade": DownloadableImage(
+            urljoin(
+                urljoin(base_sanakoyeu, "0085/"), "Places365_val_00012263_content.jpg"
+            ),
+            md5="8f4719f5f26ede9ea350102bd5a5a6e1",
+        ),
+        "waterway": DownloadableImage(
+            urljoin(
+                urljoin(base_sanakoyeu, "0086/"), "Places365_val_00012321_content.jpg"
+            ),
+            md5="9b0e9aecf9cab7e956b3d3e999c0db0e",
+        ),
+        "garden_parc": DownloadableImage(
+            urljoin(
+                urljoin(base_sanakoyeu, "0087/"), "Places365_val_00012339_content.jpg"
+            ),
+            md5="213680b20c63cfa981dcc0455276b79f",
+        ),
+    }
+
+    return DownloadableImageCollection({**content_images})
 
 
 class WikiArt(ImageFolderDataset):

--- a/pystiche_papers/sanakoyeu_et_al_2018/_data.py
+++ b/pystiche_papers/sanakoyeu_et_al_2018/_data.py
@@ -260,30 +260,39 @@ def url(
 ) -> str:
     return urljoin(base, f"{id:04d}/{file}")
 
+
 def images() -> DownloadableImageCollection:
     content_images = {
-        "garden": DownloadableImage(url(63, "Places365_val_00009975_content.jpg"),
+        "garden": DownloadableImage(
+            url(63, "Places365_val_00009975_content.jpg"),
             md5="f08cfeef2e020555e6bcf0f15d9d0e36",
         ),
-        "bridge_river": DownloadableImage(url(65, "Places365_val_00010170_content.jpg"),
+        "bridge_river": DownloadableImage(
+            url(65, "Places365_val_00010170_content.jpg"),
             md5="df290455d760e566b498878edb07e82c",
         ),
-        "glacier_human": DownloadableImage(url(66, "Places365_val_00010262_content.jpg"),
+        "glacier_human": DownloadableImage(
+            url(66, "Places365_val_00010262_content.jpg"),
             md5="420b014fc6b2e059a7c421ee5409495e",
         ),
-        "mountain": DownloadableImage(url(74, "Places365_val_00010926_content.jpg"),
+        "mountain": DownloadableImage(
+            url(74, "Places365_val_00010926_content.jpg"),
             md5="127ae1ad474a24a763d2f4f43b1c311e",
         ),
-        "horses": DownloadableImage(url(76, "Places365_val_00010957_content.jpg"),
+        "horses": DownloadableImage(
+            url(76, "Places365_val_00010957_content.jpg"),
             md5="99658ffb5cea1275cf2411ba431a5b3c",
         ),
-        "stone_facade": DownloadableImage(url(85, "Places365_val_00012263_content.jpg"),
+        "stone_facade": DownloadableImage(
+            url(85, "Places365_val_00012263_content.jpg"),
             md5="8f4719f5f26ede9ea350102bd5a5a6e1",
         ),
-        "waterway": DownloadableImage(url(86, "Places365_val_00012321_content.jpg"),
+        "waterway": DownloadableImage(
+            url(86, "Places365_val_00012321_content.jpg"),
             md5="9b0e9aecf9cab7e956b3d3e999c0db0e",
         ),
-        "garden_parc": DownloadableImage(url(87, "Places365_val_00012339_content.jpg"),
+        "garden_parc": DownloadableImage(
+            url(87, "Places365_val_00012339_content.jpg"),
             md5="213680b20c63cfa981dcc0455276b79f",
         ),
     }

--- a/pystiche_papers/sanakoyeu_et_al_2018/_data.py
+++ b/pystiche_papers/sanakoyeu_et_al_2018/_data.py
@@ -253,55 +253,37 @@ def image_transform(impl_params: bool = True, edge_size: int = 768) -> nn.Sequen
     return nn.Sequential(*transforms_)
 
 
+def url(
+    id: int,
+    file: str,
+    base: str = "https://raw.githubusercontent.com/CompVis/adaptive-style-transfer/gh-pages/images/experiments/comparison_with_others/",
+) -> str:
+    return urljoin(base, f"{id:04d}/{file}")
+
 def images() -> DownloadableImageCollection:
-    base_sanakoyeu = "https://raw.githubusercontent.com/CompVis/adaptive-style-transfer/gh-pages/images/experiments/comparison_with_others/"
     content_images = {
-        "garden": DownloadableImage(
-            urljoin(
-                urljoin(base_sanakoyeu, "0063/"), "Places365_val_00009975_content.jpg"
-            ),
+        "garden": DownloadableImage(url(63, "Places365_val_00009975_content.jpg"),
             md5="f08cfeef2e020555e6bcf0f15d9d0e36",
         ),
-        "bridge_river": DownloadableImage(
-            urljoin(
-                urljoin(base_sanakoyeu, "0065/"), "Places365_val_00010170_content.jpg"
-            ),
+        "bridge_river": DownloadableImage(url(65, "Places365_val_00010170_content.jpg"),
             md5="df290455d760e566b498878edb07e82c",
         ),
-        "glacier_human": DownloadableImage(
-            urljoin(
-                urljoin(base_sanakoyeu, "0066/"), "Places365_val_00010262_content.jpg"
-            ),
+        "glacier_human": DownloadableImage(url(66, "Places365_val_00010262_content.jpg"),
             md5="420b014fc6b2e059a7c421ee5409495e",
         ),
-        "mountain": DownloadableImage(
-            urljoin(
-                urljoin(base_sanakoyeu, "0074/"), "Places365_val_00010926_content.jpg"
-            ),
+        "mountain": DownloadableImage(url(74, "Places365_val_00010926_content.jpg"),
             md5="127ae1ad474a24a763d2f4f43b1c311e",
         ),
-        "horses": DownloadableImage(
-            urljoin(
-                urljoin(base_sanakoyeu, "0076/"), "Places365_val_00010957_content.jpg"
-            ),
+        "horses": DownloadableImage(url(76, "Places365_val_00010957_content.jpg"),
             md5="99658ffb5cea1275cf2411ba431a5b3c",
         ),
-        "stone_facade": DownloadableImage(
-            urljoin(
-                urljoin(base_sanakoyeu, "0085/"), "Places365_val_00012263_content.jpg"
-            ),
+        "stone_facade": DownloadableImage(url(85, "Places365_val_00012263_content.jpg"),
             md5="8f4719f5f26ede9ea350102bd5a5a6e1",
         ),
-        "waterway": DownloadableImage(
-            urljoin(
-                urljoin(base_sanakoyeu, "0086/"), "Places365_val_00012321_content.jpg"
-            ),
+        "waterway": DownloadableImage(url(86, "Places365_val_00012321_content.jpg"),
             md5="9b0e9aecf9cab7e956b3d3e999c0db0e",
         ),
-        "garden_parc": DownloadableImage(
-            urljoin(
-                urljoin(base_sanakoyeu, "0087/"), "Places365_val_00012339_content.jpg"
-            ),
+        "garden_parc": DownloadableImage(url(87, "Places365_val_00012339_content.jpg"),
             md5="213680b20c63cfa981dcc0455276b79f",
         ),
     }

--- a/tests/download/test_images.py
+++ b/tests/download/test_images.py
@@ -14,6 +14,7 @@ IMAGES_AND_IDS = [
         "gatys_et_al_2017",
         "johnson_alahi_li_2016",
         "li_wand_2016",
+        "sanakoyeu_et_al_2018",
         "ulyanov_et_al_2016",
     )
     for name, image in importlib.import_module(f"pystiche_papers.{paper}").images()

--- a/tests/unit/sanakoyeu_et_al_2018/test_data.py
+++ b/tests/unit/sanakoyeu_et_al_2018/test_data.py
@@ -14,7 +14,7 @@ from torch.utils.data.sampler import RandomSampler
 import pystiche
 import pystiche.image.transforms.functional as F
 import pystiche_papers.sanakoyeu_et_al_2018 as paper
-from pystiche.data import ImageFolderDataset
+from pystiche.data import DownloadableImageCollection, ImageFolderDataset
 from pystiche.image import (
     extract_edge_size,
     extract_image_size,
@@ -200,6 +200,10 @@ def test_image_transform_impl_params():
     expected = transform(image)
 
     ptu.assert_allclose(actual, expected)
+
+
+def test_images_smoke():
+    assert isinstance(paper.images(), DownloadableImageCollection)
 
 
 def test_WikiArt_unknown_style(tmpdir):


### PR DESCRIPTION
Add some of the content images used to compare the replication with the original implementation.

These images are used in the implementation when comparing the functionality for different styles. See [here](https://github.com/CompVis/adaptive-style-transfer/tree/gh-pages/images/experiments/comparison_with_others).