### PR TITLE
Fix normalization for GramOperator from ulyanov_et_al_2016

### DIFF
--- a/pystiche_papers/ulyanov_et_al_2016/_loss.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_loss.py
@@ -91,8 +91,8 @@ class GramOperator(ops.GramOperator):
         self, encoder: enc.Encoder, impl_params: bool = True, **gram_op_kwargs: Any,
     ):
         super().__init__(encoder, **gram_op_kwargs)
+        # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/src/texture_loss.lua#L38
         self.normalize_by_num_channels = impl_params
-        self.loss_reduction = "mean"
         # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L217
         # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L162
         # nn.MSECriterion() was used to calculate the style loss, which by default uses

--- a/pystiche_papers/ulyanov_et_al_2016/_loss.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_loss.py
@@ -91,7 +91,8 @@ class GramOperator(ops.GramOperator):
         self, encoder: enc.Encoder, impl_params: bool = True, **gram_op_kwargs: Any,
     ):
         # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/src/texture_loss.lua#L38
-        # In the reference implementation the output is only divided by the batch_size.
+        # In the reference implementation the gram_matrix is only divided by the
+        # batch_size.
         normalize = not impl_params
         self.normalize_by_num_channels = impl_params
         super().__init__(encoder, normalize=normalize, **gram_op_kwargs)

--- a/pystiche_papers/ulyanov_et_al_2016/_loss.py
+++ b/pystiche_papers/ulyanov_et_al_2016/_loss.py
@@ -90,9 +90,12 @@ class GramOperator(ops.GramOperator):
     def __init__(
         self, encoder: enc.Encoder, impl_params: bool = True, **gram_op_kwargs: Any,
     ):
-        super().__init__(encoder, **gram_op_kwargs)
         # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/src/texture_loss.lua#L38
+        # In the reference implementation the output is only divided by the batch_size.
+        normalize = not impl_params
         self.normalize_by_num_channels = impl_params
+        super().__init__(encoder, normalize=normalize, **gram_op_kwargs)
+
         # https://github.com/pmeier/texture_nets/blob/aad2cc6f8a998fedc77b64bdcfe1e2884aa0fb3e/train.lua#L217
         # https://github.com/pmeier/texture_nets/blob/b2097eccaec699039038970b191780f97c238816/stylization_train.lua#L162
         # nn.MSECriterion() was used to calculate the style loss, which by default uses

--- a/tests/unit/ulyanov_et_al_2016/test_loss.py
+++ b/tests/unit/ulyanov_et_al_2016/test_loss.py
@@ -63,12 +63,19 @@ def test_GramOperator(
 ):
     multi_layer_encoder, layer = multi_layer_encoder_with_layer
     encoder = multi_layer_encoder.extract_encoder(layer)
-    target_repr = pystiche.gram_matrix(encoder(target_image), normalize=True)
-    input_repr = pystiche.gram_matrix(encoder(input_image), normalize=True)
 
-    configs = ((True, True, 1.0), (False, False, input_repr.size()[0]))
-    for impl_params, normalize_by_num_channels, extra_batch_normalization in configs:
+    configs = ((True, True, 1.0, False), (False, False, input_image.size()[0], True))
+    for (
+        impl_params,
+        normalize_by_num_channels,
+        extra_batch_normalization,
+        normalize,
+    ) in configs:
         with subtests.test(impl_params=impl_params):
+            target_repr = pystiche.gram_matrix(
+                encoder(target_image), normalize=normalize
+            )
+            input_repr = pystiche.gram_matrix(encoder(input_image), normalize=normalize)
             intern_target_repr = (
                 target_repr / target_repr.size()[-1]
                 if normalize_by_num_channels
@@ -79,7 +86,7 @@ def test_GramOperator(
                 if normalize_by_num_channels
                 else input_repr
             )
-            op = paper.GramOperator(encoder, impl_params=impl_params,)
+            op = paper.GramOperator(encoder, impl_params=impl_params)
             op.set_target_image(target_image)
             actual = op(input_image)
 


### PR DESCRIPTION
Noted in [#219](https://github.com/pmeier/pystiche_papers/issues/219). I added the permalink and removed the superfluous line.