### PR TITLE
Li wand score correction factor

### DIFF
--- a/pystiche_papers/li_wand_2016/_loss.py
+++ b/pystiche_papers/li_wand_2016/_loss.py
@@ -99,9 +99,12 @@ class MRFOperator(ops.MRFOperator):
         # the paper.
         self.normalize_patches_grad = impl_params
         self.loss_reduction = "sum"
-        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/mylib/style.lua#L34
-        # nn.MSECriterion() was used as criterion to calculate the style loss, which
-        # does not include the factor 1/2 given in the paper
+
+        # The score correction factor is not visible in the reference implementation
+        # of the original authors, since the calculation is performed with respect to
+        # the gradient and not the score. Roughly speaking, since the calculation
+        # comprises a *squared* distance, we need a factor of 1/2 in the forward pass.
+        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/mylib/mrf.lua#L220
         self.score_correction_factor = 1.0 / 2.0 if impl_params else 1.0
 
     def enc_to_repr(self, enc: torch.Tensor, is_guided: bool) -> torch.Tensor:
@@ -226,6 +229,12 @@ class TotalVariationOperator(ops.TotalVariationOperator):
         super().__init__(**total_variation_op_kwargs)
 
         self.loss_reduction = "sum"
+
+        # The score correction factor is not visible in the reference implementation
+        # of the original authors, since the calculation is performed with respect to
+        # the gradient and not the score. Roughly speaking, since the calculation
+        # comprises a *squared* distance, we need a factor of 1/2 in the forward pass.
+        # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/mylib/tv.lua#L20-L30
         self.score_correction_factor = 1.0 / 2.0 if impl_params else 1.0
 
     def calculate_score(self, input_repr: torch.Tensor) -> torch.Tensor:

--- a/pystiche_papers/li_wand_2016/_loss.py
+++ b/pystiche_papers/li_wand_2016/_loss.py
@@ -102,7 +102,7 @@ class MRFOperator(ops.MRFOperator):
         # https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/mylib/style.lua#L34
         # nn.MSECriterion() was used as criterion to calculate the style loss, which
         # does not include the factor 1/2 given in the paper
-        self.score_correction_factor = 1.0 if impl_params else 1.0 / 2.0
+        self.score_correction_factor = 1.0 / 2.0 if impl_params else 1.0
 
     def enc_to_repr(self, enc: torch.Tensor, is_guided: bool) -> torch.Tensor:
         if self.normalize_patches_grad:
@@ -226,7 +226,7 @@ class TotalVariationOperator(ops.TotalVariationOperator):
         super().__init__(**total_variation_op_kwargs)
 
         self.loss_reduction = "sum"
-        self.score_correction_factor = 1.0 if impl_params else 1.0 / 2.0
+        self.score_correction_factor = 1.0 / 2.0 if impl_params else 1.0
 
     def calculate_score(self, input_repr: torch.Tensor) -> torch.Tensor:
         score = F.total_variation_loss(

--- a/tests/unit/li_wand_2016/test_loss.py
+++ b/tests/unit/li_wand_2016/test_loss.py
@@ -55,7 +55,8 @@ def test_MRFOperator(
 
     patch_size = 3
     stride = 1
-    for impl_params in (True, False):
+    configs = ((True, 1.0), (False, 1.0 / 2.0))
+    for (impl_params, score_correction_factor,) in configs:
         with subtests.test(impl_params=impl_params):
 
             op = paper.MRFOperator(
@@ -72,7 +73,8 @@ def test_MRFOperator(
             target_repr = extract_patches2d(target_enc, patch_size, stride)
             input_repr = extract_patches2d(input_enc, patch_size, stride)
 
-            desired = F.mrf_loss(input_repr, target_repr, reduction="sum")
+            score = F.mrf_loss(input_repr, target_repr, reduction="sum")
+            desired = score * score_correction_factor
 
             assert actual == ptu.approx(desired)
 
@@ -128,12 +130,19 @@ def test_style_loss_target_transforms(
 
 
 def test_TotalVariationOperator(subtests, input_image):
-    op = paper.TotalVariationOperator()
-    actual = op(input_image)
+    configs = ((True, 1.0), (False, 1.0 / 2.0))
+    for impl_params, score_correction_factor in configs:
+        with subtests.test(impl_params=impl_params):
+            op = paper.TotalVariationOperator(impl_params=impl_params,)
+            actual = op(input_image)
 
-    desired = F.total_variation_loss(input_image, exponent=op.exponent, reduction="sum")
+            score = F.total_variation_loss(
+                input_image, exponent=op.exponent, reduction="sum"
+            )
 
-    assert actual == ptu.approx(desired)
+            desired = score * score_correction_factor
+
+            assert actual == ptu.approx(desired)
 
 
 def test_regularization(subtests):

--- a/tests/unit/li_wand_2016/test_loss.py
+++ b/tests/unit/li_wand_2016/test_loss.py
@@ -55,7 +55,7 @@ def test_MRFOperator(
 
     patch_size = 3
     stride = 1
-    configs = ((True, 1.0), (False, 1.0 / 2.0))
+    configs = ((True, 1.0 / 2.0), (False, 1.0))
     for (impl_params, score_correction_factor,) in configs:
         with subtests.test(impl_params=impl_params):
 
@@ -130,7 +130,7 @@ def test_style_loss_target_transforms(
 
 
 def test_TotalVariationOperator(subtests, input_image):
-    configs = ((True, 1.0), (False, 1.0 / 2.0))
+    configs = ((True, 1.0 / 2.0), (False, 1.0))
     for impl_params, score_correction_factor in configs:
         with subtests.test(impl_params=impl_params):
             op = paper.TotalVariationOperator(impl_params=impl_params,)


### PR DESCRIPTION
I finally remembered why I added the `score_correction_factor` for the implementation parameters: the key observation is that the functionalities are implemented in the backward rather than the forward pass. That means, the gradient is calculated rather than the loss.

Roughly speaking, if we are **not** seeing any correction factor in the gradient calculation, it has to appear in the score calculation.  Since the loss is calculated with the **squared** euclidean distance, we need a `score_correction_factor=0.5` to compensate for that.

For example, look at the gradient calculation of the total variation loss in the [reference implementation of the original authors](https://github.com/pmeier/CNNMRF/blob/fddcf4d01e2a6ce201059d8bc38597f74a09ba3f/mylib/tv.lua#L20-L30) and compare it to `pystiche`s implementation:

```python
import torch
import pystiche.ops.functional as F

input = torch.rand(1, 3, 128, 128, requires_grad=True)

horz_diff = input[..., :-1, :-1] - input[..., :-1, 1:]
vert_diff = input[..., :-1, :-1] - input[..., 1:, :-1]

grad = torch.zeros_like(input)
grad[..., :-1, :-1] = horz_diff + vert_diff
grad[..., :-1, 1:] -= horz_diff
grad[..., 1:, :-1] -= vert_diff

score_correction_factor = 0.5
loss = score_correction_factor * F.total_variation_loss(input, exponent=2.0, reduction="sum")
loss.backward()

assert torch.allclose(input.grad, grad)
```

Without `score_correction_factor=0.5` this would not be the same. The same holds true for the MRF loss.

Cc @jbueltemeier 
