### PR TITLE
perform augmentation transforms on GPU

### DIFF
--- a/pystiche_papers/sanakoyeu_et_al_2018/_nst.py
+++ b/pystiche_papers/sanakoyeu_et_al_2018/_nst.py
@@ -33,9 +33,9 @@ __all__ = [
 
 def _maybe_extract_transform(image_loader: DataLoader) -> Optional[Callable]:
     try:
-        transform = image_loader.dataset.transform
-        image_loader.dataset.transform = None
-        return transform
+        transform = image_loader.dataset.transform  # type: ignore[attr-defined]
+        image_loader.dataset.transform = None  # type: ignore[attr-defined]
+        return cast(Callable, transform)
     except AttributeError:
         return None
 


### PR DESCRIPTION
Right now the augmentation transforms in `sanakoyeu_et_al_2018` are part of the `transform` of the dataset. Since they will always be performed on the CPU, this is a bottleneck during training. This fix (or rather hack) extracts the transforms from the datasets and only applies them **after** the batch is pushed to the GPU.

Since this also affects the default model optimization, this should be fixed in `pystiche` in the long term.