### PR TITLE
adapt pre- and postprocessor based on impl_params 

### DIFF
--- a/pystiche_papers/johnson_alahi_li_2016/_utils.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_utils.py
@@ -35,6 +35,17 @@ def _maybe_get_luatorch_param(
 
 
 def preprocessor(impl_params: bool = True) -> nn.Module:
+    r"""Preprocessor from :cite:`JAL2016`.
+
+    Args:
+        impl_params: If ``True``, the input is preprocessed for models trained with
+            the Caffe framework. If ``False``, the preprocessor performs the identity
+            operation.
+
+    .. seealso::
+
+        - :class:`pystiche.image.transforms.CaffePreprocessing`
+    """
     # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/fast_neural_style/preprocess.lua#L57-L62
     # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/fast_neural_style/DataLoader.lua#L92
     # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/train.lua#L133
@@ -42,6 +53,17 @@ def preprocessor(impl_params: bool = True) -> nn.Module:
 
 
 def postprocessor(impl_params: bool = True) -> nn.Module:
+    r"""Preprocessor from :cite:`JAL2016`.
+
+    Args:
+        impl_params: If ``True``, the input is postprocessed from models trained with
+            the Caffe framework. If ``False``, the postprocessor performs the identity
+            operation.
+
+    .. seealso::
+
+        - :class:`pystiche.image.transforms.CaffePostprocessing`
+    """
     # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/fast_neural_style/preprocess.lua#L66-L71
     # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/fast_neural_style.lua#L89
     return transforms.CaffePostprocessing() if impl_params else Identity()

--- a/pystiche_papers/johnson_alahi_li_2016/_utils.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_utils.py
@@ -4,6 +4,7 @@ from torch import nn, optim
 
 from pystiche import enc
 from pystiche.image import transforms
+from pystiche_papers.utils import Identity
 
 __all__ = [
     "_maybe_get_luatorch_param",
@@ -33,12 +34,17 @@ def _maybe_get_luatorch_param(
         return default
 
 
-def preprocessor() -> transforms.CaffePreprocessing:
-    return transforms.CaffePreprocessing()
+def preprocessor(impl_params: bool = True) -> transforms.CaffePreprocessing:
+    # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/fast_neural_style/preprocess.lua#L57-L62
+    # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/fast_neural_style/DataLoader.lua#L92
+    # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/train.lua#L133
+    return transforms.CaffePreprocessing() if impl_params else Identity()
 
 
-def postprocessor() -> transforms.CaffePostprocessing:
-    return transforms.CaffePostprocessing()
+def postprocessor(impl_params: bool = True) -> transforms.CaffePostprocessing:
+    # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/fast_neural_style/preprocess.lua#L66-L71
+    # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/fast_neural_style.lua#L89
+    return transforms.CaffePostprocessing() if impl_params else Identity()
 
 
 def multi_layer_encoder(impl_params: bool = True,) -> enc.VGGMultiLayerEncoder:

--- a/pystiche_papers/johnson_alahi_li_2016/_utils.py
+++ b/pystiche_papers/johnson_alahi_li_2016/_utils.py
@@ -34,14 +34,14 @@ def _maybe_get_luatorch_param(
         return default
 
 
-def preprocessor(impl_params: bool = True) -> transforms.CaffePreprocessing:
+def preprocessor(impl_params: bool = True) -> nn.Module:
     # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/fast_neural_style/preprocess.lua#L57-L62
     # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/fast_neural_style/DataLoader.lua#L92
     # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/train.lua#L133
     return transforms.CaffePreprocessing() if impl_params else Identity()
 
 
-def postprocessor(impl_params: bool = True) -> transforms.CaffePostprocessing:
+def postprocessor(impl_params: bool = True) -> nn.Module:
     # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/fast_neural_style/preprocess.lua#L66-L71
     # https://github.com/pmeier/fast-neural-style/blob/813c83441953ead2adb3f65f4cc2d5599d735fa7/fast_neural_style.lua#L89
     return transforms.CaffePostprocessing() if impl_params else Identity()

--- a/tests/unit/johnson_alahi_li_2016/test_nst.py
+++ b/tests/unit/johnson_alahi_li_2016/test_nst.py
@@ -346,26 +346,6 @@ def test_training_criterion_style_image(
     )
 
 
-def test_training_criterion_style_image_no_preprocessing(
-    preprocessor_mocks,
-    optimizer_mocks,
-    style_transforms_mocks,
-    transformer_mocks,
-    training,
-    image_loader,
-    style_image,
-):
-    _, style_transform = style_transforms_mocks
-
-    args, _, _ = training(image_loader, style_image, impl_params=False)
-    criterion = args[2]
-
-    ptu.assert_allclose(
-        criterion.style_loss.get_target_image(),
-        style_transform(utils.batch_up_image(style_image, image_loader.batch_size)),
-    )
-
-
 def test_training_criterion_update_fn(
     preprocessor_mocks,
     optimizer_mocks,
@@ -510,20 +490,3 @@ def test_stylization_transformer_str(
 
     with subtests.test("eval"):
         mock.eval.assert_called_once_with()
-
-
-def test_stylization_no_pre_post_processing(
-    subtests,
-    preprocessor_mocks,
-    postprocessor_mocks,
-    transformer_mocks,
-    input_image,
-    stylization,
-):
-    mocks = (preprocessor_mocks, postprocessor_mocks)
-
-    stylization(impl_params=False)
-
-    for _, mock in mocks:
-        with subtests.test(mock.name):
-            mock.assert_not_called()

--- a/tests/unit/johnson_alahi_li_2016/test_utils.py
+++ b/tests/unit/johnson_alahi_li_2016/test_utils.py
@@ -9,11 +9,27 @@ from pystiche.image import transforms
 
 
 def test_preprocessor():
-    assert isinstance(paper.preprocessor(), transforms.CaffePreprocessing)
+    assert isinstance(
+        paper.preprocessor(impl_params=True), transforms.CaffePreprocessing
+    )
+
+
+def test_preprocessor_noop(input_image):
+    preprocessor = paper.preprocessor(impl_params=False)
+    assert isinstance(preprocessor, nn.Module)
+    ptu.assert_allclose(preprocessor(input_image), input_image)
 
 
 def test_postprocessor():
-    assert isinstance(paper.postprocessor(), transforms.CaffePostprocessing)
+    assert isinstance(
+        paper.postprocessor(impl_params=True), transforms.CaffePostprocessing
+    )
+
+
+def test_postprocessor_noop(input_image):
+    postprocessor = paper.postprocessor(impl_params=False)
+    assert isinstance(postprocessor, nn.Module)
+    ptu.assert_allclose(postprocessor(input_image), input_image)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
In `johnson_alahi_li_2016` we need to differentiate between `impl_params` if a pre- and postprocessor is used. Right now, we are doing this in the training and stylization functions

https://github.com/pmeier/pystiche_papers/blob/55315e080eca09b19508764918aad50921dc7ef6/pystiche_papers/johnson_alahi_li_2016/_nst.py#L65

https://github.com/pmeier/pystiche_papers/blob/55315e080eca09b19508764918aad50921dc7ef6/pystiche_papers/johnson_alahi_li_2016/_nst.py#L158-L159

while the definition of the pre- and postprocessors do not differentiate:

https://github.com/pmeier/pystiche_papers/blob/55315e080eca09b19508764918aad50921dc7ef6/pystiche_papers/johnson_alahi_li_2016/_utils.py#L36-L41

This PR moves this functionality to the definition of the pre- and postprocessor and always uses them in the stylization and training functions.


